### PR TITLE
Add throwErrorCode parameter

### DIFF
--- a/system/MockBox.cfc
+++ b/system/MockBox.cfc
@@ -326,6 +326,7 @@ Description		:
 		<cfargument name="throwType" 	  		type="string"   required="false" default="" hint="The type of the exception to throw"/>
 		<cfargument name="throwDetail" 	  		type="string"   required="false" default="" hint="The detail of the exception to throw"/>
 		<cfargument name="throwMessage"	  		type="string"   required="false" default="" hint="The message of the exception to throw"/>
+		<cfargument name="throwErrorCode"  		type="string"   required="false" default="" hint="The errorCode of the exception to throw"/>
 		<cfargument name="callLogging" 	  		type="boolean"  required="false" default="false" hint="Will add the machinery to also log the incoming arguments to each subsequent calls to this method"/>
 		<cfargument name="preserveArguments" 	type="boolean"  required="false" default="false" hint="If true, argument signatures are kept, else they are ignored. If true, BEWARE with $args() matching as default values and missing arguments need to be passed too."/>
 		<cfargument name="callback" 			type="any" 		required="false" hint="A callback to execute that should return the desired results, this can be a UDF or closure."/>

--- a/system/mockutils/MockGenerator.cfc
+++ b/system/mockutils/MockGenerator.cfc
@@ -36,6 +36,7 @@ Description		:
 		<cfargument name="throwType" 	  		type="string" 	required="false" 	default="" hint="The type of the exception to throw"/>
 		<cfargument name="throwDetail" 	  		type="string" 	required="false" 	default="" hint="The detail of the exception to throw"/>
 		<cfargument name="throwMessage"	  		type="string" 	required="false" 	default="" hint="The message of the exception to throw"/>
+		<cfargument name="throwErrorCode"  		type="string"   required="false" default="" hint="The errorCode of the exception to throw"/>
 		<cfargument name="metadata" 	  		type="any" 		required="true" 	default="" hint="The function metadata"/>
 		<cfargument name="targetObject"	  		type="any" 		required="true" 	hint="The target object to mix in"/>
 		<cfargument name="callLogging" 	  		type="boolean" 	required="false" 	default="false" hint="Will add the machinery to also log the incoming arguments to each subsequent calls to this method"/>
@@ -121,7 +122,7 @@ Description		:
 
 			// Exceptions? To Throw
 			if( arguments.throwException ){
-				udfOut.append('<cfthrow type="#arguments.throwType#" message="#arguments.throwMessage#" detail="#arguments.throwDetail#" />#instance.lb#');
+				udfOut.append('<cfthrow type="#arguments.throwType#" message="#arguments.throwMessage#" detail="#arguments.throwDetail#" errorCode="#arguments.throwErrorCode#" />#instance.lb#');
 			}
 
 			// Returns Something according to metadata?


### PR DESCRIPTION
Adding the throwErrorCode parameter to allow the ability to throw an exception from a mock with an errorCode.

The errorCode parameter is as per the Coldfusion docs and we rely on it quite heavily in our applications.

https://wikidocs.adobe.com/wiki/display/coldfusionen/Throw