### PR TITLE
Add errorCode as validation option

### DIFF
--- a/system/Expectation.cfc
+++ b/system/Expectation.cfc
@@ -313,7 +313,7 @@ component accessors="true"{
 	* @regex Match this regex against the message of the exception
 	* @message The message to send in the failure
 	*/
-	function toThrow( type="", regex=".*", message="" ){
+	function toThrow( type="", regex=".*", errorCode="", message="" ){
 		arguments.target = this.actual;
 		if( this.isNot ){
 			variables.assert.notThrows( argumentCollection=arguments );


### PR DESCRIPTION
When testing for errors it makes sense to be able to assert on the errorCode that is returned by a throw.

I would dare say error codes (API status codes, http status codes, etc...) are more widely used than error messages or even types. In this case one could test for any combination of the three: type, errorCode, message.

@lmajano please review.