### PR TITLE
Add simple support for Given-When-Then test style syntax

### DIFF
--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -195,6 +195,82 @@ component{
 	}
 
 	/**
+	* The way to describe BDD test suites in TestBox. The feature is an alias for describe usually use when you are writing in a Given-When-Then style
+	* The body is the function that implements the suite.
+	* @feature The name of this test suite
+	* @body The closure that represents the test suite
+	* @labels The list or array of labels this suite group belongs to
+	* @asyncAll If you want to parallelize the execution of the defined specs in this suite group.
+	* @skip A flag or a closure that tells TestBox to skip this suite group from testing if true. If this is a closure it must return boolean.
+	*/
+	any function feature(
+		required string feature,
+		required any body,
+		any labels=[],
+		boolean asyncAll=false,
+		any skip=false
+	){
+		return describe(argumentCollection=arguments, title="Feature: " & arguments.feature);
+	}
+
+	/**
+	* The way to describe BDD test suites in TestBox. The given is an alias for describe usually use when you are writing in a Given-When-Then style
+	* The body is the function that implements the suite.
+	* @feature The name of this test suite
+	* @body The closure that represents the test suite
+	* @labels The list or array of labels this suite group belongs to
+	* @asyncAll If you want to parallelize the execution of the defined specs in this suite group.
+	* @skip A flag or a closure that tells TestBox to skip this suite group from testing if true. If this is a closure it must return boolean.
+	*/
+	any function given(
+		required string given,
+		required any body,
+		any labels=[],
+		boolean asyncAll=false,
+		any skip=false
+	){
+		return describe(argumentCollection=arguments, title="Given " & arguments.given);
+	}
+
+	/**
+	* The way to describe BDD test suites in TestBox. The scenario is an alias for describe usually use when you are writing in a Given-When-Then style
+	* The body is the function that implements the suite.
+	* @feature The name of this test suite
+	* @body The closure that represents the test suite
+	* @labels The list or array of labels this suite group belongs to
+	* @asyncAll If you want to parallelize the execution of the defined specs in this suite group.
+	* @skip A flag or a closure that tells TestBox to skip this suite group from testing if true. If this is a closure it must return boolean.
+	*/
+	any function scenario(
+		required string scenario,
+		required any body,
+		any labels=[],
+		boolean asyncAll=false,
+		any skip=false
+	){
+		return describe(argumentCollection=arguments, title="Scenario: " & arguments.scenario);
+	}
+
+	/**
+	* The way to describe BDD test suites in TestBox. The when is an alias for scenario usually use when you are writing in a Given-When-Then style
+	* The body is the function that implements the suite.
+	* @feature The name of this test suite
+	* @body The closure that represents the test suite
+	* @labels The list or array of labels this suite group belongs to
+	* @asyncAll If you want to parallelize the execution of the defined specs in this suite group.
+	* @skip A flag or a closure that tells TestBox to skip this suite group from testing if true. If this is a closure it must return boolean.
+	*/
+	any function when(
+		required string when,
+		required any body,
+		any labels=[],
+		boolean asyncAll=false,
+		any skip=false
+	){
+		return describe(argumentCollection=arguments, title="When " & arguments.when);
+	}
+
+	/**
 	* The it() function describes a spec or a test in TestBox.  The body argument is the closure that implements
 	* the test which usually contains one or more expectations that test the state of the code under test.
 	* @title The title of this spec
@@ -244,6 +320,25 @@ component{
 		arrayAppend( this.$suitesReverseLookup[ this.$suiteContext ].specs, spec );
 
 		return this;
+	}
+
+
+
+	/**
+	* The then() function describes a spec or a test in TestBox and is an alias for it.  The body argument is the closure that implements
+	* the test which usually contains one or more expectations that test the state of the code under test.
+	* @then The title of this spec
+	* @body The closure that represents the test
+	* @labels The list or array of labels this spec belongs to
+	* @skip A flag or a closure that tells TestBox to skip this spec test from testing if true. If this is a closure it must return boolean.
+	*/
+	any function then(
+		required string then,
+		required any body,
+		any labels=[],
+		any skip=false
+	){
+		return it(argumentCollection=arguments, title="Then " & arguments.then);
 	}
 
 	/**

--- a/tests/specs/GivenWhenThenTest.cfc
+++ b/tests/specs/GivenWhenThenTest.cfc
@@ -1,0 +1,32 @@
+/**
+* My BDD Test
+*/
+component extends="testbox.system.BaseSpec"{
+
+/*********************************** LIFE CYCLE Methods ***********************************/
+
+	// executes before all suites+specs in the run() method
+	function beforeAll(){
+	}
+
+	// executes after all suites+specs in the run() method
+	function afterAll(){
+	}
+
+/*********************************** BDD SUITES ***********************************/
+
+	function run(){
+		feature( "Given-When-Then test language support", function(){
+			scenario( "I want to be able to write tests using Given-When-Then language", function(){
+				given( "I am using TestBox", function(){
+					when( "I run this test suite", function(){
+						then( "it should be supported", function(){
+							expect( true ).toBe( true );
+						});
+					});
+				});
+			});
+		});
+	}
+
+}


### PR DESCRIPTION
Reference: http://martinfowler.com/bliki/GivenWhenThen.html

I think it'd be great if TestBox supported the Given-When-Then style of writing tests. For example if my requirements are:

```
Feature: Given-When-Then syntax idea
  Scenario: I want to promote BDD in the team
    Given I am using TestBox
      When I write my tests
        Then it should read as a given-when-then style of representing tests
```

It would be nice if, instead of having multiple nested describe calls, I could write my test using those phases, something like:

```
feature("Given-When-Then syntax idea", function() {
  scenario("I want to promote BDD in the team", function() {
    given("I am using TestBox", function() { // setup
      when("I write my tests", function() {
        then("it should read as a given-when-then style of representing tests", function() {
          expect(syntaxSupported).toBeTrue("I think this would be nice syntactic sugar");
        });
      });
    });
  });
});
```

The `feature/scenario/given` functions are a simple alias for the existing describe function. 
The `then` function is a simple alias for the existing it function.
