### PR TITLE
Add story alias for describe

### DIFF
--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -193,6 +193,25 @@ component{
 
 		return this;
 	}
+	
+	/**
+	* The way to describe BDD test suites in TestBox. The story is an alias for describe usually use when you are writing using Gherkin-esque language
+	* The body is the function that implements the suite.
+	* @story The name of this test suite
+	* @body The closure that represents the test suite
+	* @labels The list or array of labels this suite group belongs to
+	* @asyncAll If you want to parallelize the execution of the defined specs in this suite group.
+	* @skip A flag or a closure that tells TestBox to skip this suite group from testing if true. If this is a closure it must return boolean.
+	*/
+	any function story(
+		required string story,
+		required any body,
+		any labels=[],
+		boolean asyncAll=false,
+		any skip=false
+	){
+		return describe(argumentCollection=arguments, title="Story: " & arguments.story);
+	}
 
 	/**
 	* The way to describe BDD test suites in TestBox. The feature is an alias for describe usually use when you are writing in a Given-When-Then style


### PR DESCRIPTION
Add `story` as syntactical sugar for the existing `describe` method to support a Agile / Gherkin-esque language.

This is an extension to the PR https://github.com/Ortus-Solutions/TestBox/pull/12 which is already merged into development branch.