### PR TITLE
Explicitly place the instance "scope" in the variables scope.

### DIFF
--- a/system/MockBox.cfc
+++ b/system/MockBox.cfc
@@ -18,7 +18,7 @@ Description		:
 		<cfscript>
 			var tempDir =  "/testbox/system/stubs";
 
-			instance = structnew();
+			variables.instance = structnew();
 
 			// Setup the generation Path
 			if( len(trim(arguments.generationPath)) neq 0 ){

--- a/system/mockutils/MockGenerator.cfc
+++ b/system/mockutils/MockGenerator.cfc
@@ -11,7 +11,7 @@ Description		:
 <cfcomponent output="false" hint="The guy in charge of creating mocks">
 
 	<cfscript>
-		instance = structnew();
+		variables.instance = structnew();
 	</cfscript>
 
 	<cffunction name="init" access="public" output="false" returntype="MockGenerator" hint="Constructor">

--- a/system/util/MixerUtil.cfc
+++ b/system/util/MixerUtil.cfc
@@ -14,7 +14,7 @@ Description :
 
 	<cffunction name="init" access="public" returntype="MixerUtil" output="false" hint="Constructor">
 		<cfscript>
-			instance = structnew();
+			variables.instance = structnew();
 			instance.mixins = StructNew();
 
 			// Place our methods on the mixins struct


### PR DESCRIPTION
This allows TestBox to work in Lucee when `localMode="modern"` in application.cfc