### PR TITLE
Add annotation hooks for lifecycle methods

### DIFF
--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -750,41 +750,41 @@ component{
     */
     function generateAroundEachClosuresStack( array closures, required suite, required spec ) {
 
-        variables.closures 	= arguments.closures;
-        variables.suite 	= arguments.suite;
-        variables.spec 		= arguments.spec;
+        thread.closures = arguments.closures;
+        thread.suite 	= arguments.suite;
+        thread.spec 	= arguments.spec;
 
         // Get closure data from stack and pop it
-        var nextClosure = variables.closures[ 1 ];
-        arrayDeleteAt( variables.closures, 1 );
+        var nextClosure = thread.closures[ 1 ];
+        arrayDeleteAt( thread.closures, 1 );
 
         // Check if we have more in the stack or empty
-        if( arrayLen( variables.closures ) == 0 ){
+        if( arrayLen( thread.closures ) == 0 ){
         	// Return the closure of execution for a single spec ONLY
             return function(){
             	// Execute the body of the spec
-                nextClosure.body( spec = variables.spec, suite = variables.suite );
+                nextClosure.body( spec = thread.spec, suite = thread.suite );
             };
         }
 
         // Get next Spec in stack
-        var nextSpecInfo = variables.closures[ 1 ];
+        var nextSpecInfo = thread.closures[ 1 ];
         // Return generated closure
         return function() {
             nextClosure.body(
                 {
                     name = nextSpecInfo.name,
                     body = generateAroundEachClosuresStack(
-                        variables.closures,
-                        variables.suite,
-                        variables.spec
+                        thread.closures,
+                        thread.suite,
+                        thread.spec
                     ),
                     data = nextSpecInfo.data,
                     labels = nextSpecInfo.labels,
                     order = nextSpecInfo.order,
                     skip = nextSpecInfo.skip
                 },
-                variables.suite
+                thread.suite
             );
         };
     }

--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -492,25 +492,36 @@ component{
 		return this;
 	}
 
-    public function getAnnotatedMethods(required string annotation, required struct metadata) {
+    /**
+     * Find all methods on a given metadata and it's parents with a given annotation
+     *
+     * @annotation The annotation name to look for on methods
+     * @metadata The metadata to search (recursively) for the provided annotation
+     */
+    private function getAnnotatedMethods(
+        required string annotation,
+        required struct metadata
+    ){
         var lifecycleMethods = [];
 
-        if (StructKeyExists(arguments.metadata, "functions")) {
+        if( StructKeyExists( arguments.metadata, "functions" ) ){
             var funcs = arguments.metadata.functions;
-            lifecycleMethods.addAll(ArrayFilter(funcs, function(func) {
-                return StructKeyExists(func, annotation);
-            }));
+            lifecycleMethods.addAll( ArrayFilter( funcs, function( func ){
+                return StructKeyExists( func, annotation );
+            } ) );
         }
 
-        if (StructKeyExists(arguments.metadata, "extends")) {
-            lifecycleMethods.addAll(getAnnotatedMethods(arguments.annotation, arguments.metadata.extends));
+        if( StructKeyExists( arguments.metadata, "extends" ) ){
+            // recursively call up the inheritance chain
+            lifecycleMethods.addAll(
+                getAnnotatedMethods(
+                    arguments.annotation,
+                    arguments.metadata.extends
+                )
+            );
         }
 
         return lifecycleMethods;
-    }
-
-    private function generateClosure(required string functionName) {
-
     }
 
 	/************************************** RUN BDD METHODS *********************************************/
@@ -637,10 +648,13 @@ component{
 			parentSuite = parentSuite.parentRef;
 		}
 
-        var annotationMethods = getAnnotatedMethods(annotation = "beforeEach", metadata = getMetadata(this));
+        var annotationMethods = getAnnotatedMethods(
+            annotation = "beforeEach",
+            metadata   = getMetadata( this )
+        );
 
-        for (var method in annotationMethods) {
-            arrayAppend( reverseTree, this[method.name] );
+        for( var method in annotationMethods ){
+            arrayAppend( reverseTree, this[ method.name ] );
         }
 
 		// Execute reverse tree
@@ -690,9 +704,12 @@ component{
             parentSuite = parentSuite.parentRef;
         }
 
-        var annotationMethods = getAnnotatedMethods(annotation = "aroundEach", metadata = getMetadata(this));
+        var annotationMethods = getAnnotatedMethods(
+            annotation = "aroundEach",
+            metadata   = getMetadata( this )
+        );
 
-        for (var method in annotationMethods) {
+        for( var method in annotationMethods ){
             arrayAppend( reverseTree, {
                 name 	= method.name,
                 body 	= this[method.name],
@@ -788,12 +805,16 @@ component{
 			parentSuite = parentSuite.parentRef;
 		}
 
-        var annotationMethods = getAnnotatedMethods(annotation = "afterEach", metadata = getMetadata(this));
+        var annotationMethods = getAnnotatedMethods(
+            annotation = "afterEach",
+            metadata = getMetadata( this )
+        );
 
-        for (var method in annotationMethods) {
-            var afterEachMethod = this[method.name];
-            afterEachMethod(currentSpec = arguments.spec.name);
+        for( var method in annotationMethods ){
+            var afterEachMethod = this[ method.name ];
+            afterEachMethod( currentSpec = arguments.spec.name );
         }
+
 		return this;
 	}
 

--- a/system/runners/BDDRunner.cfc
+++ b/system/runners/BDDRunner.cfc
@@ -59,6 +59,19 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 					arguments.target.beforeAll();
 				}
 
+                // find any methods annotated 'beforeAll' and execute them
+                var beforeAllAnnotationMethods = getAnnotatedMethods(
+                    annotation = "beforeAll",
+                    metadata   = getMetadata( arguments.target )
+                );
+
+                for (var beforeAllMethod in beforeAllAnnotationMethods) {
+                    // We use evalute here for two reasons:
+                    // 1. We want the scopes to be the target class, not this one.
+                    // 2. We want this code to be cross-platform ( hence no cfinvoke() )
+                    Evaluate( "arguments.target.#beforeAllMethod.name#()" );
+                }
+
 				// Iterate over found test suites and test them, if nested suites, then this will recurse as well.
 				for( var thisSuite in testSuites ){
 					// verify call backs
@@ -67,7 +80,7 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 					}
 
 					// Test Suite
-					testSuite( 
+					testSuite(
 						target=arguments.target,
 						suite=thisSuite,
 						testResults=arguments.testResults,
@@ -85,6 +98,19 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 				if( structKeyExists( arguments.target, "afterAll" ) ){
 					arguments.target.afterAll();
 				}
+
+                // find any methods annotated 'afterAll' and execute them
+                var afterAllAnnotationMethods = getAnnotatedMethods(
+                    annotation = "afterAll",
+                    metadata   = getMetadata( arguments.target )
+                );
+
+                for (var afterAllMethod in afterAllAnnotationMethods) {
+                    // We use evalute here for two reasons:
+                    // 1. We want the scopes to be the target class, not this one.
+                    // 2. We want this code to be cross-platform ( hence no cfinvoke() )
+                    Evaluate( "arguments.target.#afterAllMethod.name#()" );
+                }
 
 			} catch(Any e) {
 				bundleStats.globalException = e;
@@ -162,9 +188,9 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 					// append to used thread names
 					arrayAppend( threadNames, thisThreadName );
 					// thread it
-					thread 	name="#thisThreadName#" 
-							thisSpec="#thisSpec#" 
-							suite="#arguments.suite#" 
+					thread 	name="#thisThreadName#"
+							thisSpec="#thisSpec#"
+							suite="#arguments.suite#"
 							threadName="#thisThreadName#"
 							callbacks="#arguments.callbacks#"{
 
@@ -174,12 +200,12 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 						}
 
 						// execute the test within the context of the spec target due to lucee closure bug, move back once it is resolved.
-						thread.target.runSpec( 
+						thread.target.runSpec(
 							spec=attributes.thisSpec,
 							suite=attributes.suite,
 							testResults=thread.testResults,
 							suiteStats=thread.suiteStats,
-							runner=this 
+							runner=this
 						);
 
 						// verify call backs
@@ -195,12 +221,12 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 					}
 
 					// execute the test within the context of the spec target due to lucee closure bug, move back once it is resolved.
-					thread.target.runSpec( 
+					thread.target.runSpec(
 						spec=thisSpec,
 						suite=arguments.suite,
 						testResults=thread.testResults,
 						suiteStats=thread.suiteStats,
-						runner=this 
+						runner=this
 					);
 
 					// verify call backs
@@ -222,7 +248,7 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 			for( var thisInternalSuite in arguments.suite.suites ){
 
 				// run the suite specs recursively
-				testSuite( 
+				testSuite(
 					target=arguments.target,
 					suite=thisInternalSuite,
 					testResults=arguments.testResults,
@@ -274,5 +300,37 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 		// get the spec suites
 		return arguments.target.$suites;
 	}
+
+    /**
+     * Find all methods on a given metadata and it's parents with a given annotation
+     *
+     * @annotation The annotation name to look for on methods
+     * @metadata The metadata to search (recursively) for the provided annotation
+     */
+    private function getAnnotatedMethods(
+        required string annotation,
+        required struct metadata
+    ){
+        var lifecycleMethods = [];
+
+        if( StructKeyExists( arguments.metadata, "functions" ) ){
+            var funcs = arguments.metadata.functions;
+            lifecycleMethods.addAll( ArrayFilter( funcs, function( func ){
+                return StructKeyExists( func, annotation );
+            } ) );
+        }
+
+        if( StructKeyExists( arguments.metadata, "extends" ) ){
+            // recursively call up the inheritance chain
+            lifecycleMethods.addAll(
+                getAnnotatedMethods(
+                    arguments.annotation,
+                    arguments.metadata.extends
+                )
+            );
+        }
+
+        return lifecycleMethods;
+    }
 
 }

--- a/tests/specs/BDDInheritanceTest.cfc
+++ b/tests/specs/BDDInheritanceTest.cfc
@@ -10,14 +10,14 @@ component extends="testbox.system.BaseSpec"{
 	}
 
 	function afterAll(){
-		structClear( application );	
+		structClear( application );
 	}
 
 /*********************************** BDD SUITES ***********************************/
 
 	function run(){
 
-		/** 
+		/**
 		* describe() starts a suite group of spec tests.
 		* Arguments:
 		* @title The title of the suite, Usually how you want to name the desired behavior
@@ -27,19 +27,19 @@ component extends="testbox.system.BaseSpec"{
 		* @skip A flag that tells TestBox to skip this suite group from testing if true
 		*/
 		describe( "A spec", function(){
-		
+
 			// before each spec in THIS suite group
 			beforeEach(function(){
 				coldbox = 0;
 				coldbox++;
 			});
-			
+
 			// after each spec in THIS suite group
 			afterEach(function(){
 				foo = 0;
 			});
-			
-			/** 
+
+			/**
 			* it() describes a spec to test. Usually the title is prefixed with the suite name to create an expression.
 			* Arguments:
 			* @title The title of the spec
@@ -50,7 +50,7 @@ component extends="testbox.system.BaseSpec"{
 			it("is just a closure so it can contain code", function(){
 				expect( coldbox ).toBe( 1 );
 			});
-			
+
 			// more than 1 expectation
 			it("can have more than one expectation test", function(){
 				coldbox = coldbox * 8;
@@ -74,12 +74,12 @@ component extends="testbox.system.BaseSpec"{
 				// delta ranges
 				expect( coldbox ).notToBeCloseTo( expected=10, delta=2 );
 			});
-			
+
 			// xit() skips
 			xit("can have tests that can be skipped easily like this one", function(){
-				fail( "xit() this should skip" );	
+				fail( "xit() this should skip" );
 			});
-			
+
 			// acf dynamic skips
 			it( title="can have tests that execute if the right environment exists (Lucee only)", body=function(){
 				expect( server ).toHaveKey( "Lucee" );
@@ -89,12 +89,12 @@ component extends="testbox.system.BaseSpec"{
 			it( title="can have tests that execute if the right environment exists (acf only)", body=function(){
 				expect( server ).notToHaveKey( "Lucee" );
 			}, skip=( isLucee() ));
-			
+
 			// specs with a random skip closure
 			it(title="can have a skip that is executed at runtime", body=function(){
 				fail( "Skipped programmatically, this should fail" );
 			},skip=function(){ return true; });
-		
+
 		});
 
 

--- a/tests/specs/BDDLifecycleAnnotationsTest.cfc
+++ b/tests/specs/BDDLifecycleAnnotationsTest.cfc
@@ -1,0 +1,49 @@
+/**
+* This tests the BDD functionality in TestBox.
+*/
+component extends="tests.utils.ExampleParentTestCase"{
+
+/*********************************** LIFE CYCLE Methods ***********************************/
+
+	function beforeAll(){
+        variables.counter = 0;
+	}
+
+	function afterAll(){
+		structClear( variables );
+	}
+
+    /**
+     * @aroundEach
+     */
+    function testAroundEach(spec, suite) {
+        variables.counter++;
+        arguments.spec.body();
+    }
+
+/*********************************** BDD SUITES ***********************************/
+
+	function run(){
+
+		describe( "Lifecycle annotations", function(){
+
+			it("runs lifecycle annotation hooks just as if they were in the suite", function(){
+				expect( variables.counter ).toBe( 2 );
+			});
+
+            describe( "Lifecycle Annotation Hooks with normal Lifecycle Methods", function() {
+                beforeEach(function() {
+                    variables.counter++;
+                })
+
+                it("runs both types of methods", function() {
+                    expect( variables.counter ).toBe( 5 );
+                });
+            });
+
+		});
+
+
+	}
+
+}

--- a/tests/specs/BDDLifecycleAnnotationsTest.cfc
+++ b/tests/specs/BDDLifecycleAnnotationsTest.cfc
@@ -28,7 +28,7 @@ component extends="tests.utils.ExampleParentTestCase"{
 		describe( "Lifecycle annotations", function(){
 
 			it("runs lifecycle annotation hooks just as if they were in the suite", function(){
-				expect( variables.counter ).toBe( 2 );
+				expect( variables.counter ).toBe( 4 );
 			});
 
             describe( "Lifecycle Annotation Hooks with normal Lifecycle Methods", function() {
@@ -37,7 +37,7 @@ component extends="tests.utils.ExampleParentTestCase"{
                 })
 
                 it("runs both types of methods", function() {
-                    expect( variables.counter ).toBe( 5 );
+                    expect( variables.counter ).toBe( 8 );
                 });
             });
 

--- a/tests/utils/ExampleParentTestCase.cfc
+++ b/tests/utils/ExampleParentTestCase.cfc
@@ -1,0 +1,20 @@
+component extends="testbox.system.BaseSpec" {
+
+    /**
+     * @beforeEach
+     */
+    function runThisBefore() {
+        variables.counter++;
+    }
+
+    /**
+     * @afterEach
+     */
+    function runThisAfter(currentSpec) {
+        if (arguments.currentSpec == "runs lifecycle annotation hooks just as if they were in the suite") {
+            expect(variables.counter).toBe(2);
+        } else {
+            expect(variables.counter).toBe(5);
+        }
+    }
+}

--- a/tests/utils/ExampleParentTestCase.cfc
+++ b/tests/utils/ExampleParentTestCase.cfc
@@ -1,9 +1,31 @@
 component extends="testbox.system.BaseSpec" {
 
     /**
+     * @beforeAll
+     */
+    function initializeCounter() {
+        expect(variables.counter).toBe(0);
+        variables.counter = 1;
+    }
+
+    /**
+     * @afterAll
+     */
+    function setCounterBackToZero() {
+        variables.counter = 0;
+    }
+
+    /**
      * @beforeEach
      */
     function runThisBefore() {
+        variables.counter++;
+    }
+
+    /**
+     * @beforeEach
+     */
+    function runThisBeforeAsWell() {
         variables.counter++;
     }
 
@@ -12,9 +34,9 @@ component extends="testbox.system.BaseSpec" {
      */
     function runThisAfter(currentSpec) {
         if (arguments.currentSpec == "runs lifecycle annotation hooks just as if they were in the suite") {
-            expect(variables.counter).toBe(2);
+            expect(variables.counter).toBe(4);
         } else {
-            expect(variables.counter).toBe(5);
+            expect(variables.counter).toBe(8);
         }
     }
 }


### PR DESCRIPTION
Add annotation hooks for beforeEach, aroundEach, and afterEach lifecycle methods on BDD tests.

This can be used by parent classes to add lifecycle functionality to a test case.
One example of this would be a `testing.DatabaseTest` parent class which automatically surrounds each spec in a database transaction.