### PR TITLE
remove the TestBox tag contexts from the beginning of Failure Origins

### DIFF
--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -581,7 +581,8 @@ component{
 			// store spec status and debug data
 			specStats.status 		= "Failed";
 			specStats.failMessage 	= e.message;
-			specStats.failOrigin 	= e.tagContext;
+			specStats.failOrigin 	= this.sliceTagContext(e.tagContext);
+
 			// Increment recursive pass stats
 			arguments.testResults.incrementSpecStat( type="fail", stats=specStats );
 		}
@@ -822,7 +823,8 @@ component{
 			// store spec status and debug data
 			specStats.status 		= "Failed";
 			specStats.failMessage 	= e.message;
-			specStats.failOrigin 	= e.tagContext;
+			specStats.failOrigin 	= this.sliceTagContext(e.tagContext);
+
 			// Increment recursive pass stats
 			arguments.testResults.incrementSpecStat( type="fail", stats=specStats );
 		}
@@ -1077,4 +1079,40 @@ component{
 
 		return results;
 	}
+
+
+	/**
+	* removes the TestBox tag contexts from the beginning of the Failure Origin
+	*/
+	private function sliceTagContext(tagContext) {
+
+		var result = arguments.tagContext;
+
+		var testcasePath = getDirectoryFromPath(getCurrentTemplatePath());
+		var ix = 1;
+
+		for (var tc in arguments.tagContext) {
+
+			if (find(testcasePath, tc.template) == 1)
+				break;
+
+			ix++;
+		}
+
+		if (ix > 1) {
+
+			// result = arraySlice(result, ix);		/* commented out to support CF9
+			
+			result = arrayNew();
+			var len = arrayLen(arguments.tagContext);
+
+			while (ix < len) {
+
+				arrayAppend(result, arguments.tagContext[ix++]);
+			}	//*/
+		}
+		
+		return result;
+	}
+
 }


### PR DESCRIPTION
The Failure Origin currently always starts with the TestBox templates, which adds clutter with no real useful information.

The proposed patch starts the tag contexts at the testcase, instead of TestBox.