### PR TITLE
Lifecycle annotation hooks

### DIFF
--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -492,38 +492,6 @@ component{
 		return this;
 	}
 
-    /**
-     * Find all methods on a given metadata and it's parents with a given annotation
-     *
-     * @annotation The annotation name to look for on methods
-     * @metadata The metadata to search (recursively) for the provided annotation
-     */
-    private function getAnnotatedMethods(
-        required string annotation,
-        required struct metadata
-    ){
-        var lifecycleMethods = [];
-
-        if( StructKeyExists( arguments.metadata, "functions" ) ){
-            var funcs = arguments.metadata.functions;
-            lifecycleMethods.addAll( ArrayFilter( funcs, function( func ){
-                return StructKeyExists( func, annotation );
-            } ) );
-        }
-
-        if( StructKeyExists( arguments.metadata, "extends" ) ){
-            // recursively call up the inheritance chain
-            lifecycleMethods.addAll(
-                getAnnotatedMethods(
-                    arguments.annotation,
-                    arguments.metadata.extends
-                )
-            );
-        }
-
-        return lifecycleMethods;
-    }
-
 	/************************************** RUN BDD METHODS *********************************************/
 
 	/**
@@ -650,7 +618,7 @@ component{
 			parentSuite = parentSuite.parentRef;
 		}
 
-        var annotationMethods = getAnnotatedMethods(
+        var annotationMethods = this.$utility.getAnnotatedMethods(
             annotation = "beforeEach",
             metadata   = getMetadata( this )
         );
@@ -706,7 +674,7 @@ component{
             parentSuite = parentSuite.parentRef;
         }
 
-        var annotationMethods = getAnnotatedMethods(
+        var annotationMethods = this.$utility.getAnnotatedMethods(
             annotation = "aroundEach",
             metadata   = getMetadata( this )
         );
@@ -807,7 +775,7 @@ component{
 			parentSuite = parentSuite.parentRef;
 		}
 
-        var annotationMethods = getAnnotatedMethods(
+        var annotationMethods = this.$utility.getAnnotatedMethods(
             annotation = "afterEach",
             metadata = getMetadata( this )
         );

--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -492,25 +492,36 @@ component{
 		return this;
 	}
 
-    public function getAnnotatedMethods(required string annotation, required struct metadata) {
+    /**
+     * Find all methods on a given metadata and it's parents with a given annotation
+     *
+     * @annotation The annotation name to look for on methods
+     * @metadata The metadata to search (recursively) for the provided annotation
+     */
+    private function getAnnotatedMethods(
+        required string annotation,
+        required struct metadata
+    ){
         var lifecycleMethods = [];
 
-        if (StructKeyExists(arguments.metadata, "functions")) {
+        if( StructKeyExists( arguments.metadata, "functions" ) ){
             var funcs = arguments.metadata.functions;
-            lifecycleMethods.addAll(ArrayFilter(funcs, function(func) {
-                return StructKeyExists(func, annotation);
-            }));
+            lifecycleMethods.addAll( ArrayFilter( funcs, function( func ){
+                return StructKeyExists( func, annotation );
+            } ) );
         }
 
-        if (StructKeyExists(arguments.metadata, "extends")) {
-            lifecycleMethods.addAll(getAnnotatedMethods(arguments.annotation, arguments.metadata.extends));
+        if( StructKeyExists( arguments.metadata, "extends" ) ){
+            // recursively call up the inheritance chain
+            lifecycleMethods.addAll(
+                getAnnotatedMethods(
+                    arguments.annotation,
+                    arguments.metadata.extends
+                )
+            );
         }
 
         return lifecycleMethods;
-    }
-
-    private function generateClosure(required string functionName) {
-
     }
 
 	/************************************** RUN BDD METHODS *********************************************/
@@ -639,10 +650,13 @@ component{
 			parentSuite = parentSuite.parentRef;
 		}
 
-        var annotationMethods = getAnnotatedMethods(annotation = "beforeEach", metadata = getMetadata(this));
+        var annotationMethods = getAnnotatedMethods(
+            annotation = "beforeEach",
+            metadata   = getMetadata( this )
+        );
 
-        for (var method in annotationMethods) {
-            arrayAppend( reverseTree, this[method.name] );
+        for( var method in annotationMethods ){
+            arrayAppend( reverseTree, this[ method.name ] );
         }
 
 		// Execute reverse tree
@@ -692,9 +706,12 @@ component{
             parentSuite = parentSuite.parentRef;
         }
 
-        var annotationMethods = getAnnotatedMethods(annotation = "aroundEach", metadata = getMetadata(this));
+        var annotationMethods = getAnnotatedMethods(
+            annotation = "aroundEach",
+            metadata   = getMetadata( this )
+        );
 
-        for (var method in annotationMethods) {
+        for( var method in annotationMethods ){
             arrayAppend( reverseTree, {
                 name 	= method.name,
                 body 	= this[method.name],
@@ -790,12 +807,16 @@ component{
 			parentSuite = parentSuite.parentRef;
 		}
 
-        var annotationMethods = getAnnotatedMethods(annotation = "afterEach", metadata = getMetadata(this));
+        var annotationMethods = getAnnotatedMethods(
+            annotation = "afterEach",
+            metadata = getMetadata( this )
+        );
 
-        for (var method in annotationMethods) {
-            var afterEachMethod = this[method.name];
-            afterEachMethod(currentSpec = arguments.spec.name);
+        for( var method in annotationMethods ){
+            var afterEachMethod = this[ method.name ];
+            afterEachMethod( currentSpec = arguments.spec.name );
         }
+
 		return this;
 	}
 

--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -752,41 +752,41 @@ component{
     */
     function generateAroundEachClosuresStack( array closures, required suite, required spec ) {
 
-        variables.closures 	= arguments.closures;
-        variables.suite 	= arguments.suite;
-        variables.spec 		= arguments.spec;
+        thread.closures = arguments.closures;
+        thread.suite 	= arguments.suite;
+        thread.spec 	= arguments.spec;
 
         // Get closure data from stack and pop it
-        var nextClosure = variables.closures[ 1 ];
-        arrayDeleteAt( variables.closures, 1 );
+        var nextClosure = thread.closures[ 1 ];
+        arrayDeleteAt( thread.closures, 1 );
 
         // Check if we have more in the stack or empty
-        if( arrayLen( variables.closures ) == 0 ){
+        if( arrayLen( thread.closures ) == 0 ){
         	// Return the closure of execution for a single spec ONLY
             return function(){
             	// Execute the body of the spec
-                nextClosure.body( spec = variables.spec, suite = variables.suite );
+                nextClosure.body( spec = thread.spec, suite = thread.suite );
             };
         }
 
         // Get next Spec in stack
-        var nextSpecInfo = variables.closures[ 1 ];
+        var nextSpecInfo = thread.closures[ 1 ];
         // Return generated closure
         return function() {
             nextClosure.body(
                 {
                     name = nextSpecInfo.name,
                     body = generateAroundEachClosuresStack(
-                        variables.closures,
-                        variables.suite,
-                        variables.spec
+                        thread.closures,
+                        thread.suite,
+                        thread.spec
                     ),
                     data = nextSpecInfo.data,
                     labels = nextSpecInfo.labels,
                     order = nextSpecInfo.order,
                     skip = nextSpecInfo.skip
                 },
-                variables.suite
+                thread.suite
             );
         };
     }

--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -492,6 +492,27 @@ component{
 		return this;
 	}
 
+    public function getAnnotatedMethods(required string annotation, required struct metadata) {
+        var lifecycleMethods = [];
+
+        if (StructKeyExists(arguments.metadata, "functions")) {
+            var funcs = arguments.metadata.functions;
+            lifecycleMethods.addAll(ArrayFilter(funcs, function(func) {
+                return StructKeyExists(func, annotation);
+            }));
+        }
+
+        if (StructKeyExists(arguments.metadata, "extends")) {
+            lifecycleMethods.addAll(getAnnotatedMethods(arguments.annotation, arguments.metadata.extends));
+        }
+
+        return lifecycleMethods;
+    }
+
+    private function generateClosure(required string functionName) {
+
+    }
+
 	/************************************** RUN BDD METHODS *********************************************/
 
 	/**
@@ -618,6 +639,12 @@ component{
 			parentSuite = parentSuite.parentRef;
 		}
 
+        var annotationMethods = getAnnotatedMethods(annotation = "beforeEach", metadata = getMetadata(this));
+
+        for (var method in annotationMethods) {
+            arrayAppend( reverseTree, this[method.name] );
+        }
+
 		// Execute reverse tree
 		var treeLen = arrayLen( reverseTree );
 		if( treeLen gt 0 ){
@@ -663,6 +690,19 @@ component{
             } );
             // go deep
             parentSuite = parentSuite.parentRef;
+        }
+
+        var annotationMethods = getAnnotatedMethods(annotation = "aroundEach", metadata = getMetadata(this));
+
+        for (var method in annotationMethods) {
+            arrayAppend( reverseTree, {
+                name 	= method.name,
+                body 	= this[method.name],
+                data 	= {},
+                labels 	= {},
+                order 	= 0,
+                skip 	= false
+            } );
         }
 
         // Sort the closures from the oldest parent down to the current spec
@@ -749,6 +789,13 @@ component{
 			parentSuite.afterEach( currentSpec=arguments.spec.name );
 			parentSuite = parentSuite.parentRef;
 		}
+
+        var annotationMethods = getAnnotatedMethods(annotation = "afterEach", metadata = getMetadata(this));
+
+        for (var method in annotationMethods) {
+            var afterEachMethod = this[method.name];
+            afterEachMethod(currentSpec = arguments.spec.name);
+        }
 		return this;
 	}
 

--- a/system/runners/BDDRunner.cfc
+++ b/system/runners/BDDRunner.cfc
@@ -59,7 +59,7 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 				}
 
                 // find any methods annotated 'beforeAll' and execute them
-                var beforeAllAnnotationMethods = getAnnotatedMethods(
+                var beforeAllAnnotationMethods = variables.testbox.getUtility().getAnnotatedMethods(
                     annotation = "beforeAll",
                     metadata   = getMetadata( arguments.target )
                 );
@@ -99,7 +99,7 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 				}
 
                 // find any methods annotated 'afterAll' and execute them
-                var afterAllAnnotationMethods = getAnnotatedMethods(
+                var afterAllAnnotationMethods = variables.testbox.getUtility().getAnnotatedMethods(
                     annotation = "afterAll",
                     metadata   = getMetadata( arguments.target )
                 );
@@ -299,37 +299,5 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 		// get the spec suites
 		return arguments.target.$suites;
 	}
-
-    /**
-     * Find all methods on a given metadata and it's parents with a given annotation
-     *
-     * @annotation The annotation name to look for on methods
-     * @metadata The metadata to search (recursively) for the provided annotation
-     */
-    private function getAnnotatedMethods(
-        required string annotation,
-        required struct metadata
-    ){
-        var lifecycleMethods = [];
-
-        if( StructKeyExists( arguments.metadata, "functions" ) ){
-            var funcs = arguments.metadata.functions;
-            lifecycleMethods.addAll( ArrayFilter( funcs, function( func ){
-                return StructKeyExists( func, annotation );
-            } ) );
-        }
-
-        if( StructKeyExists( arguments.metadata, "extends" ) ){
-            // recursively call up the inheritance chain
-            lifecycleMethods.addAll(
-                getAnnotatedMethods(
-                    arguments.annotation,
-                    arguments.metadata.extends
-                )
-            );
-        }
-
-        return lifecycleMethods;
-    }
 
 }

--- a/system/runners/BDDRunner.cfc
+++ b/system/runners/BDDRunner.cfc
@@ -64,7 +64,7 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
                     metadata   = getMetadata( arguments.target )
                 );
 
-                for (var beforeAllMethod in beforeAllAnnotationMethods) {
+                for ( var beforeAllMethod in beforeAllAnnotationMethods ){
                     // We use evalute here for two reasons:
                     // 1. We want the scopes to be the target class, not this one.
                     // 2. We want this code to be cross-platform ( hence no cfinvoke() )
@@ -104,7 +104,7 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
                     metadata   = getMetadata( arguments.target )
                 );
 
-                for (var afterAllMethod in afterAllAnnotationMethods) {
+                for ( var afterAllMethod in afterAllAnnotationMethods ){
                     // We use evalute here for two reasons:
                     // 1. We want the scopes to be the target class, not this one.
                     // 2. We want this code to be cross-platform ( hence no cfinvoke() )

--- a/system/runners/UnitRunner.cfc
+++ b/system/runners/UnitRunner.cfc
@@ -59,7 +59,7 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
                     metadata   = getMetadata( arguments.target )
                 );
 
-                for (var beforeAllMethod in beforeAllAnnotationMethods) {
+                for ( var beforeAllMethod in beforeAllAnnotationMethods ){
                     // We use evalute here for two reasons:
                     // 1. We want the scopes to be the target class, not this one.
                     // 2. We want this code to be cross-platform ( hence no cfinvoke() )
@@ -99,7 +99,7 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
                     metadata   = getMetadata( arguments.target )
                 );
 
-                for (var afterAllMethod in afterAllAnnotationMethods) {
+                for ( var afterAllMethod in afterAllAnnotationMethods ){
                     // We use evalute here for two reasons:
                     // 1. We want the scopes to be the target class, not this one.
                     // 2. We want this code to be cross-platform ( hence no cfinvoke() )

--- a/system/runners/UnitRunner.cfc
+++ b/system/runners/UnitRunner.cfc
@@ -52,6 +52,20 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 			try{
 				// execute beforeAll(), beforeTests() for this bundle, no matter how many suites they have.
 				if( structKeyExists( arguments.target, "beforeAll" ) ){ arguments.target.beforeAll(); }
+
+                // find any methods annotated 'beforeAll' and execute them
+                var beforeAllAnnotationMethods = variables.testbox.getUtility().getAnnotatedMethods(
+                    annotation = "beforeAll",
+                    metadata   = getMetadata( arguments.target )
+                );
+
+                for (var beforeAllMethod in beforeAllAnnotationMethods) {
+                    // We use evalute here for two reasons:
+                    // 1. We want the scopes to be the target class, not this one.
+                    // 2. We want this code to be cross-platform ( hence no cfinvoke() )
+                    Evaluate( "arguments.target.#beforeAllMethod.name#()" );
+                }
+
 				if( structKeyExists( arguments.target, "beforeTests" ) ){ arguments.target.beforeTests(); }
 
 				// Iterate over found test suites and test them, if nested suites, then this will recurse as well.
@@ -62,7 +76,7 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 					}
 
 					// Execute Suite
-					testSuite( 
+					testSuite(
 						target=arguments.target,
 						suite=thisSuite,
 						testResults=arguments.testResults,
@@ -78,6 +92,20 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 
 				// execute afterAll(), afterTests() for this bundle, no matter how many suites they have.
 				if( structKeyExists( arguments.target, "afterAll" ) ){ arguments.target.afterAll(); }
+
+                // find any methods annotated 'afterAll' and execute them
+                var afterAllAnnotationMethods = variables.testbox.getUtility().getAnnotatedMethods(
+                    annotation = "afterAll",
+                    metadata   = getMetadata( arguments.target )
+                );
+
+                for (var afterAllMethod in afterAllAnnotationMethods) {
+                    // We use evalute here for two reasons:
+                    // 1. We want the scopes to be the target class, not this one.
+                    // 2. We want this code to be cross-platform ( hence no cfinvoke() )
+                    Evaluate( "arguments.target.#afterAllMethod.name#()" );
+                }
+
 				if( structKeyExists( arguments.target, "afterTests" ) ){ arguments.target.afterTests(); }
 			} catch(Any e) {
 				bundleStats.globalException = e;
@@ -146,18 +174,18 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 					// append to used thread names
 					arrayAppend( threadNames, thisThreadName );
 					// thread it
-					thread  name="#thisThreadName#" 
-							thisSpec="#thisSpec#" 
-							suite="#arguments.suite#" 
+					thread  name="#thisThreadName#"
+							thisSpec="#thisSpec#"
+							suite="#arguments.suite#"
 							threadName="#thisThreadName#"{
-						
+
 						// verify call backs
 						if( structKeyExists( attributes.callbacks, "onSpecStart" ) ){
 							attributes.callbacks.onSpecStart( thread.target, thread.testResults, thread.suiteStats, attributes.thisSpec );
 						}
 
 						// execute the test within the context of the spec target due to lucee closure bug, move back once it is resolved.
-						thread.target.runTestMethod( 
+						thread.target.runTestMethod(
 							spec=attributes.thisSpec,
 							testResults=thread.testResults,
 						  	suiteStats=thread.suiteStats,
@@ -177,11 +205,11 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 					}
 
 					// execute the test within the context of the spec target due to lucee closure bug, move back once it is resolved.
-					thread.target.runTestMethod( 
+					thread.target.runTestMethod(
 						spec=thisSpec,
 						testResults=thread.testResults,
 						suiteStats=thread.suiteStats,
-						runner=this 
+						runner=this
 					);
 
 					// verify call backs

--- a/system/util/Util.cfc
+++ b/system/util/Util.cfc
@@ -1,4 +1,4 @@
-﻿/**
+/**
 * Copyright Since 2005 TestBox Framework by Luis Majano and Ortus Solutions, Corp
 * www.ortussolutions.com
 * ---
@@ -111,4 +111,36 @@ component{
 		return slug;
 	}
 
-}	
+
+	/**
+	* Find all methods on a given metadata and it's parents with a given annotation
+	* @annotation The annotation name to look for on methods
+	* @metadata The metadata to search (recursively) for the provided annotation
+	*/
+    public array function getAnnotatedMethods(
+		required string annotation,
+		required struct metadata
+	) {
+        var lifecycleMethods = [];
+
+        if( StructKeyExists( arguments.metadata, "functions" ) ){
+            var funcs = arguments.metadata.functions;
+            lifecycleMethods.addAll( ArrayFilter( funcs, function( func ){
+                return StructKeyExists( func, annotation );
+            } ) );
+        }
+
+        if( StructKeyExists( arguments.metadata, "extends" ) ){
+            // recursively call up the inheritance chain
+            lifecycleMethods.addAll(
+                getAnnotatedMethods(
+                    arguments.annotation,
+                    arguments.metadata.extends
+                )
+            );
+        }
+
+        return lifecycleMethods;
+	}
+
+}

--- a/system/util/Util.cfc
+++ b/system/util/Util.cfc
@@ -35,7 +35,7 @@ component{
 	/**
 	* Get the last modified date of a file
 	* @filename The target
-	* 
+	*
 	* @return date
 	*/
 	function fileLastModified( required filename ){
@@ -90,7 +90,7 @@ component{
 
 		return false;
 	}
-	
+
 	/**
 	* Create a URL safe slug from a string
 	* @str The target
@@ -125,9 +125,11 @@ component{
 
         if( StructKeyExists( arguments.metadata, "functions" ) ){
             var funcs = arguments.metadata.functions;
-            lifecycleMethods.addAll( ArrayFilter( funcs, function( func ){
-                return StructKeyExists( func, annotation );
-            } ) );
+            for ( var func in funcs ){
+                if ( StructKeyExists( func, annotation ) ){
+                    ArrayAppend( lifecycleMethods, func );
+                }
+            }
         }
 
         if( StructKeyExists( arguments.metadata, "extends" ) ){

--- a/tests/specs/BDDInheritanceTest.cfc
+++ b/tests/specs/BDDInheritanceTest.cfc
@@ -10,14 +10,14 @@ component extends="testbox.system.BaseSpec"{
 	}
 
 	function afterAll(){
-		structClear( application );	
+		structClear( application );
 	}
 
 /*********************************** BDD SUITES ***********************************/
 
 	function run(){
 
-		/** 
+		/**
 		* describe() starts a suite group of spec tests.
 		* Arguments:
 		* @title The title of the suite, Usually how you want to name the desired behavior
@@ -27,19 +27,19 @@ component extends="testbox.system.BaseSpec"{
 		* @skip A flag that tells TestBox to skip this suite group from testing if true
 		*/
 		describe( "A spec", function(){
-		
+
 			// before each spec in THIS suite group
 			beforeEach(function(){
 				coldbox = 0;
 				coldbox++;
 			});
-			
+
 			// after each spec in THIS suite group
 			afterEach(function(){
 				foo = 0;
 			});
-			
-			/** 
+
+			/**
 			* it() describes a spec to test. Usually the title is prefixed with the suite name to create an expression.
 			* Arguments:
 			* @title The title of the spec
@@ -50,7 +50,7 @@ component extends="testbox.system.BaseSpec"{
 			it("is just a closure so it can contain code", function(){
 				expect( coldbox ).toBe( 1 );
 			});
-			
+
 			// more than 1 expectation
 			it("can have more than one expectation test", function(){
 				coldbox = coldbox * 8;
@@ -74,12 +74,12 @@ component extends="testbox.system.BaseSpec"{
 				// delta ranges
 				expect( coldbox ).notToBeCloseTo( expected=10, delta=2 );
 			});
-			
+
 			// xit() skips
 			xit("can have tests that can be skipped easily like this one", function(){
-				fail( "xit() this should skip" );	
+				fail( "xit() this should skip" );
 			});
-			
+
 			// acf dynamic skips
 			it( title="can have tests that execute if the right environment exists (Lucee only)", body=function(){
 				expect( server ).toHaveKey( "Lucee" );
@@ -89,12 +89,12 @@ component extends="testbox.system.BaseSpec"{
 			it( title="can have tests that execute if the right environment exists (acf only)", body=function(){
 				expect( server ).notToHaveKey( "Lucee" );
 			}, skip=( isLucee() ));
-			
+
 			// specs with a random skip closure
 			it(title="can have a skip that is executed at runtime", body=function(){
 				fail( "Skipped programmatically, this should fail" );
 			},skip=function(){ return true; });
-		
+
 		});
 
 

--- a/tests/specs/BDDLifecycleAnnotationsTest.cfc
+++ b/tests/specs/BDDLifecycleAnnotationsTest.cfc
@@ -1,0 +1,49 @@
+/**
+* This tests the BDD functionality in TestBox.
+*/
+component extends="tests.utils.ExampleParentTestCase"{
+
+/*********************************** LIFE CYCLE Methods ***********************************/
+
+	function beforeAll(){
+        variables.counter = 0;
+	}
+
+	function afterAll(){
+		structClear( variables );
+	}
+
+    /**
+     * @aroundEach
+     */
+    function testAroundEach(spec, suite) {
+        variables.counter++;
+        arguments.spec.body();
+    }
+
+/*********************************** BDD SUITES ***********************************/
+
+	function run(){
+
+		describe( "Lifecycle annotations", function(){
+
+			it("runs lifecycle annotation hooks just as if they were in the suite", function(){
+				expect( variables.counter ).toBe( 2 );
+			});
+
+            describe( "Lifecycle Annotation Hooks with normal Lifecycle Methods", function() {
+                beforeEach(function() {
+                    variables.counter++;
+                })
+
+                it("runs both types of methods", function() {
+                    expect( variables.counter ).toBe( 5 );
+                });
+            });
+
+		});
+
+
+	}
+
+}

--- a/tests/specs/BDDLifecycleAnnotationsTest.cfc
+++ b/tests/specs/BDDLifecycleAnnotationsTest.cfc
@@ -16,7 +16,7 @@ component extends="tests.utils.ExampleParentTestCase"{
     /**
      * @aroundEach
      */
-    function testAroundEach(spec, suite) {
+    function testAroundEach( spec, suite ){
         variables.counter++;
         arguments.spec.body();
     }

--- a/tests/specs/BDDLifecycleAnnotationsTest.cfc
+++ b/tests/specs/BDDLifecycleAnnotationsTest.cfc
@@ -28,7 +28,7 @@ component extends="tests.utils.ExampleParentTestCase"{
 		describe( "Lifecycle annotations", function(){
 
 			it("runs lifecycle annotation hooks just as if they were in the suite", function(){
-				expect( variables.counter ).toBe( 2 );
+				expect( variables.counter ).toBe( 4 );
 			});
 
             describe( "Lifecycle Annotation Hooks with normal Lifecycle Methods", function() {
@@ -37,7 +37,7 @@ component extends="tests.utils.ExampleParentTestCase"{
                 })
 
                 it("runs both types of methods", function() {
-                    expect( variables.counter ).toBe( 5 );
+                    expect( variables.counter ).toBe( 8 );
                 });
             });
 

--- a/tests/utils/ExampleParentTestCase.cfc
+++ b/tests/utils/ExampleParentTestCase.cfc
@@ -1,0 +1,20 @@
+component extends="testbox.system.BaseSpec" {
+
+    /**
+     * @beforeEach
+     */
+    function runThisBefore() {
+        variables.counter++;
+    }
+
+    /**
+     * @afterEach
+     */
+    function runThisAfter(currentSpec) {
+        if (arguments.currentSpec == "runs lifecycle annotation hooks just as if they were in the suite") {
+            expect(variables.counter).toBe(2);
+        } else {
+            expect(variables.counter).toBe(5);
+        }
+    }
+}

--- a/tests/utils/ExampleParentTestCase.cfc
+++ b/tests/utils/ExampleParentTestCase.cfc
@@ -1,9 +1,31 @@
 component extends="testbox.system.BaseSpec" {
 
     /**
+     * @beforeAll
+     */
+    function initializeCounter() {
+        expect(variables.counter).toBe(0);
+        variables.counter = 1;
+    }
+
+    /**
+     * @afterAll
+     */
+    function setCounterBackToZero() {
+        variables.counter = 0;
+    }
+
+    /**
      * @beforeEach
      */
     function runThisBefore() {
+        variables.counter++;
+    }
+
+    /**
+     * @beforeEach
+     */
+    function runThisBeforeAsWell() {
         variables.counter++;
     }
 
@@ -12,9 +34,9 @@ component extends="testbox.system.BaseSpec" {
      */
     function runThisAfter(currentSpec) {
         if (arguments.currentSpec == "runs lifecycle annotation hooks just as if they were in the suite") {
-            expect(variables.counter).toBe(2);
+            expect(variables.counter).toBe(4);
         } else {
-            expect(variables.counter).toBe(5);
+            expect(variables.counter).toBe(8);
         }
     }
 }

--- a/tests/utils/ExampleParentTestCase.cfc
+++ b/tests/utils/ExampleParentTestCase.cfc
@@ -4,7 +4,7 @@ component extends="testbox.system.BaseSpec" {
      * @beforeAll
      */
     function initializeCounter() {
-        expect(variables.counter).toBe(0);
+        expect( variables.counter ).toBe( 0 );
         variables.counter = 1;
     }
 
@@ -33,10 +33,10 @@ component extends="testbox.system.BaseSpec" {
      * @afterEach
      */
     function runThisAfter(currentSpec) {
-        if (arguments.currentSpec == "runs lifecycle annotation hooks just as if they were in the suite") {
-            expect(variables.counter).toBe(4);
+        if ( arguments.currentSpec == "runs lifecycle annotation hooks just as if they were in the suite" ) {
+            expect( variables.counter ).toBe( 4 );
         } else {
-            expect(variables.counter).toBe(8);
+            expect( variables.counter ).toBe( 8 );
         }
     }
 }


### PR DESCRIPTION
Add annotation hooks for `beforeAll`, `afterAll`, `beforeEach`, `aroundEach`, and `afterEach` lifecycle methods on BDD tests.

This can be used by parent classes to add lifecycle functionality to a test case.
One example of this would be a testing.DatabaseTest parent class which automatically surrounds each spec in a database transaction.
