### PR TITLE
Stub out extended interface methods

### DIFF
--- a/system/mockutils/MockGenerator.cfc
+++ b/system/mockutils/MockGenerator.cfc
@@ -303,7 +303,13 @@ Description		:
 
 			// Check extends and recurse
 			if( structKeyExists( arguments.md, "extends") ){
-				generateMethodsFromMD( udfOut, arguments.md.extends );
+				var keys = StructKeyArray( arguments.md.extends );
+				if (ArrayLen(keys) == 1) {
+					generateMethodsFromMD( udfOut, arguments.md.extends[ keys[1] ] );
+				}
+				else {
+					generateMethodsFromMD( udfOut, arguments.md.extends );	
+				}
 			}
     	</cfscript>
     </cffunction>

--- a/tests/resources/NestedInterface.cfc
+++ b/tests/resources/NestedInterface.cfc
@@ -1,0 +1,3 @@
+interface extends="MyInterface" {
+	
+}

--- a/tests/resources/NestedInterface.cfc
+++ b/tests/resources/NestedInterface.cfc
@@ -1,3 +1,5 @@
 interface extends="MyInterface" {
-	
+
+	function testThisToo(required greeting, name);
+
 }

--- a/tests/specs/mockbox/MockBoxTest.cfc
+++ b/tests/specs/mockbox/MockBoxTest.cfc
@@ -319,6 +319,7 @@
 		}
 
 		function testStubInheritedInterfaces(){
+			// If this can be created, then our test has passed.
 			var canBeMockedOne = getMockBox().createStub(implements = "TestBox.tests.resources.NestedInterface");
 		}
 

--- a/tests/specs/mockbox/MockBoxTest.cfc
+++ b/tests/specs/mockbox/MockBoxTest.cfc
@@ -318,6 +318,10 @@
 			$assert.isEqual( mocked.getAmigo( "luis" ), testFunction( "luis" ) );
 		}
 
+		function testStubInheritedInterfaces(){
+			var canBeMockedOne = getMockBox().createStub(implements = "TestBox.tests.resources.NestedInterface");
+		}
+
 		private function testFunction(string amigo = "Amigo"){
 			return "Hola #arguments.amigo#!";
 		}


### PR DESCRIPTION
Correctly stub out an interface that extends another interface.