### PR TITLE
Mocking inherited interfaces

### DIFF
--- a/system/mockutils/MockGenerator.cfc
+++ b/system/mockutils/MockGenerator.cfc
@@ -303,7 +303,13 @@ Description		:
 
 			// Check extends and recurse
 			if( structKeyExists( arguments.md, "extends") ){
-				generateMethodsFromMD( udfOut, arguments.md.extends );
+				var keys = StructKeyArray( arguments.md.extends );
+				if (ArrayLen(keys) == 1) {
+					generateMethodsFromMD( udfOut, arguments.md.extends[ keys[1] ] );
+				}
+				else {
+					generateMethodsFromMD( udfOut, arguments.md.extends );	
+				}
 			}
     	</cfscript>
     </cffunction>

--- a/tests/resources/NestedInterface.cfc
+++ b/tests/resources/NestedInterface.cfc
@@ -1,0 +1,3 @@
+interface extends="MyInterface" {
+	
+}

--- a/tests/resources/NestedInterface.cfc
+++ b/tests/resources/NestedInterface.cfc
@@ -1,3 +1,5 @@
 interface extends="MyInterface" {
-	
+
+	function testThisToo(required greeting, name);
+
 }

--- a/tests/specs/mockbox/MockBoxTest.cfc
+++ b/tests/specs/mockbox/MockBoxTest.cfc
@@ -341,6 +341,7 @@
 		}
 
 		function testStubInheritedInterfaces(){
+			// If this can be created, then our test has passed.
 			var canBeMockedOne = getMockBox().createStub(implements = "TestBox.tests.resources.NestedInterface");
 		}
 

--- a/tests/specs/mockbox/MockBoxTest.cfc
+++ b/tests/specs/mockbox/MockBoxTest.cfc
@@ -1,4 +1,4 @@
-﻿<cfcomponent extends="testbox.system.BaseSpec" displayname="MockBox Suite">
+<cfcomponent extends="testbox.system.BaseSpec" displayname="MockBox Suite">
 
 	<cfscript>
 
@@ -338,6 +338,10 @@
 				type = "MyCustomException",
 				message = "My Custom Exception Message"
 			);
+		}
+
+		function testStubInheritedInterfaces(){
+			var canBeMockedOne = getMockBox().createStub(implements = "TestBox.tests.resources.NestedInterface");
 		}
 
 		private function testFunction(string amigo = "Amigo"){


### PR DESCRIPTION
Correctly stub out an interface that extends another interface.

Fixes: https://ortussolutions.atlassian.net/browse/TESTBOX-140

Side Note:
This doesn't seem to work for components that extend another component that implements interfaces. That wasn't part of the Jira ticket, so I still opened this pull request. I tried fixing that as well, but couldn't get anywhere. ¯\\_ (ツ) _/¯ 

