### PR TITLE
#12 RemoteFacade MXUnit compatiblity

### DIFF
--- a/system/compat/framework/ComponentUtils.cfc
+++ b/system/compat/framework/ComponentUtils.cfc
@@ -1,0 +1,210 @@
+<cfcomponent name="mxunit.framework.ComponentUtils" output="false" hint="Internal component not generally used outside the framework">
+
+	<cfset sep = getSeparator() />
+
+	<cffunction name="ComponentUtils" returnType="ComponentUtils" hint="Constructor"><cfreturn this /></cffunction>
+
+	<cffunction name="isFrameworkTemplate" returntype="boolean" hint="whether the passed in template is part of the mxunit framework">
+		<cfargument name="template" type="string" required="true" />
+		<!--- braindead simple.... is anything more than this necessary? --->
+		<cfif refindNoCase("mxunit(.*?)[/\\](trunk[/\\])?framework",template)
+			OR refindNoCase("[testbox|coldbox](.*?)[/\\](trunk[/\\])?system",template)>
+			<cfreturn true />
+		<cfelse>
+			<cfreturn false />
+		</cfif>
+	</cffunction>
+
+
+	<cffunction name="getSeparator" returntype="string" hint="Returns file.separator as seen by OS.">
+		<cfreturn createObject("java","java.lang.System").getProperty("file.separator") />
+	</cffunction>
+
+
+	<cffunction name="getLineSeparator" returntype="string" hint="Returns file.separator as seen by OS.">
+		<cfreturn createObject("java","java.lang.System").getProperty("line.separator") />
+	</cffunction>
+
+
+	<cffunction name="getInstallRoot" returnType="string" access="public">
+		<cfscript>
+			var root = expandPath("/");
+			var mxunit = 0;
+
+			//shortcut of the usual case of a virtualhost / alias on the web root
+			if(fileExists(expandPath("/mxunit/framework/mxunit-config.xml")))
+			{
+				return getContextRoot() &  "/mxunit";
+			}
+		</cfscript>
+
+		<!--- check for the a physical directory --->
+		<cfdirectory action="list" directory="#root#" recurse="true" name="mxunit" filter="mxunit-config.xml">
+
+		<cfif mxunit.RecordCount eq 0>
+			<cfif mxunit.RecordCount eq 0>
+				<cfthrow message="Could not find mxunit in the web root" />
+			</cfif>
+		</cfif>
+
+		<cfscript>
+			root = replaceNoCase("#mxunit.directory#/#mxunit.name#", root,"");
+			root = getDirectoryFromPath(root);
+
+			root = getContextRoot() &  "/" &  left(root, (Len(root) - Len("/framework/")));
+
+			return root;
+		</cfscript>
+	</cffunction>
+
+	<cffunction name="getComponentRoot" returnType="string" access="public">
+		<cfargument name="fullPath" type="string" required="false" default="" hint="Test Hook." />
+		<cfscript>
+			// Use the mxunit-config.xml to handle install location in case of weird behavior
+			// or if user wants custom configuration
+			var cm = createObject("component","ConfigManager").ConfigManager();
+			var userConfig = cm.getConfigElement("userConfig","componentRoot");
+			var mxUnitRoot = userConfig[1].xmlAttributes["value"];
+			var override = userConfig[1].xmlAttributes["override"];
+
+			var i = 1;//loop index
+			var sep = ".";
+			var package = arrayNew(1); //list
+			var installRoot = "";
+			//We know THIS "should" always be in mxunt.framework.ComponentUtils
+			var md = getMetaData(this);
+			var name = md.name;
+
+			//Inject fullPath argument for testing
+			if(len(arguments.fullPath)) {
+			  name = arguments.fullPath;
+			}
+
+			//Workaround for Mac/Apache configs that do not return
+			//fully qualified names for getMetaData()
+			if(name is "ComponentUtils" OR name is "" OR name is "."){
+				//use the userConfig/componentRoot element value in mxunit-config.xml
+				return(mxunitRoot);
+			}
+
+			//If user needs to override default install location.
+			// Note name is "override" is an injected test hook.
+			if(name is "override" OR override){
+			  return(mxunitRoot);
+			}
+
+			package = listToArray(name,".");
+			for(i; i lte arrayLen(package)-2; i = i + 1){
+			  installRoot = installRoot & package[i] & sep;
+			 }
+			return left(installRoot, len(installRoot)-1);
+		</cfscript>
+	</cffunction>
+
+
+	<cffunction name="dump">
+		<cfargument name="o" />
+		<cfdump var="#arguments.o#" />
+	</cffunction>
+
+	<cffunction name="hasJ2EEContext">
+		<cfreturn getContextRootPath() is not "">
+	</cffunction>
+
+	<cffunction name="getContextRootComponent">
+		<cfset var rootComponent = "" />
+		<cfset var ctx = getContextRootPath() />
+		<cfif hasJ2EEContext()>
+			<!--- This last  "." worries me. Under what circumstance will this not be true? --->
+			<cfset rootComponent = right(ctx,len(ctx)-1) &  "." />
+		</cfif>
+		<cfreturn  rootComponent />
+	</cffunction>
+
+
+	<cffunction name="getContextRootPath">
+		<cfset var ctx= "" />
+		<cfset ctx = getPageContext().getRequest().getContextPath() />
+		<cfreturn ctx />
+	</cffunction>
+
+
+	<cffunction name="isCfc" hint="Determines whether or not the given object is a ColdFusion component; Author: Nathan Dintenfass ">
+		<cfargument name="objectToCheck" />
+		<cfscript>
+			//get the meta data of the object we're inspecting
+			var metaData = getMetaData(arguments.objectToCheck);
+			//if it's an object, let's try getting the meta Data
+			if(isObject(arguments.objectToCheck)){
+			    //if it has a type, and that type is "component", then it's a component
+			    if(structKeyExists(metaData,"type") AND metaData.type is "component"){
+			        return true;
+			    }
+			}
+			//if we've gotten here, it must not have been a contentObject
+			return false;
+		</cfscript>
+	</cffunction>
+
+
+	<cffunction name="getMockFactoryInfo" returnType="any" access="public">
+		<cfargument name="factoryName" required="false" default="" />
+		<cfscript>
+			// Using the mxunit-config.xml to store the mock factory config
+			var cm = createObject("component","ConfigManager").ConfigManager();
+			var mockFactoryInfo = StructNew();
+			if (not Len(arguments.factoryName)) {
+			 arguments.factoryName = cm.getConfigElementValue("mockingFramework","name");
+			}
+			mockFactoryInfo.factoryPath = cm.getConfigElementValue(arguments.factoryName,"factoryPath");
+			mockFactoryInfo.createMockMethodName = cm.getConfigElementValue(arguments.factoryName,"createMockMethodName");
+			mockFactoryInfo.createMockStringArgumentName = cm.getConfigElementValue(arguments.factoryName,"createMockStringArgumentName");
+			mockFactoryInfo.createMockObjectArgumentName = cm.getConfigElementValue(arguments.factoryName,"createMockObjectArgumentName");
+			mockFactoryInfo.constructorName = cm.getConfigElementValue(arguments.factoryName,"constructorName");
+			mockFactoryInfo.constructorArgs = cm.getConfigElementAttributeCollection(arguments.factoryName,"constructorArgs");
+			return mockFactoryInfo;
+		</cfscript>
+	</cffunction>
+
+	<cffunction name="objectIsTypeOf" output="false" access="public" returntype="boolean" hint="returns true if the object 'type' as reported by getMetadata() matches the object's type or if the object is in the inheritance tree of the type">
+		<cfargument name="object" required="yes" type="any" />
+		<cfargument name="type" required="yes" type="string" />
+		<cfset var md = getMetaData(object)>
+		<cfset var oType = md.name>
+		<cfset var ancestry = buildInheritanceTree(md) />
+
+		<cfreturn listFindNoCase(ancestry, arguments.type)>
+    </cffunction>
+
+	<cffunction name="buildInheritanceTree" access="public" returntype="string">
+		<cfargument name="metaData" type="struct" />
+		<cfargument name="accumulator" type="string" required="false" default=""/>
+
+		<cfscript>
+			var key = "";
+
+			if( structKeyExists(arguments.metadata,"name") AND listFindNoCase(accumulator,arguments.metaData.name) eq 0 ){
+				accumulator =  accumulator & arguments.metaData.name & ",";
+			}
+
+			if(structKeyExists(arguments.metaData,"extends")){
+				//why, oh why, is the structure different for interfaces vs. extends? For F**k's sake!
+				if( structKeyExists( metadata.extends, "name" ) ){
+					accumulator = buildInheritanceTree(metaData.extends, accumulator);
+				}else{
+					accumulator = buildInheritanceTree(metadata.extends[ structKeyList(metadata.extends) ], accumulator);
+				}
+			}
+
+			if(structKeyExists(arguments.metaData,"implements")){
+				for(key in arguments.metadata.implements){
+					accumulator = buildInheritanceTree(metaData.implements[ key ], accumulator);
+				}
+			}
+
+			return  accumulator;
+		</cfscript>
+
+	</cffunction>
+
+</cfcomponent>

--- a/system/compat/framework/ConfigManager.cfc
+++ b/system/compat/framework/ConfigManager.cfc
@@ -1,0 +1,67 @@
+<cfcomponent displayname="ConfigManager" hint="Controlls data retrieved from mxunit-confg.xml" output="false">
+  <cfparam name="this.configXml" type="any" default="#xmlNew()#" />
+
+  <cffunction name="ConfigManager" access="public" output="true" returntype="ConfigManager" hint="Constructor">
+    <cfset var md = getMetadata(this) />
+    <cfset var configFilePath = "#getDirectoryfromPath(md.path)#/mxunit-config.xml" />
+	<cfset var config= "">
+    <cftry>
+     <!--- Check for file --->
+     <cfif fileexists(configFilePath)>
+      <!--- Open File --->
+      <cffile action="read" file="#configFilePath#" variable="config">
+     <cfelse>
+      <cflog file="mxunit" type="error" application="true" text="The #configFilePath# file was not found::Make sure this file is available to the application" />
+      <cfthrow type="mxunit.exception.ConfigFileNotFoundException" message="The mxunit-config.xml file was not found" detail="Make sure this file is available to the application" />
+     </cfif>
+     <!--- parse XML --->
+     <cfset this.configXml = xmlParse(config) />
+     <!--- Loop over enabled config elements and call addAssertDecorator --->
+     <cfcatch type="any">
+      <!--- Ruh-row, Raggie! --->
+      <cfthrow object="#cfcatch#">
+      <cflog file="mxunit" type="error" application="false" text="#cfcatch.message#::#cfcatch.detail#">
+     </cfcatch>
+    </cftry>
+    <cfreturn this />
+  </cffunction>
+
+
+ <cffunction name="getConfigElement" access="remote" output="false" returntype="array" hint="Given a type and name, returns the first matching XML element node.">
+    <cfargument name="type" type="string" required="true" />
+    <cfargument name="name" type="string" required="true" />
+    <cfset var element = xmlSearch(this.configXml,"/mxunit-config/config-element[@type='#arguments.type#' and @name='#arguments.name#']") />
+    <cfreturn element />
+  </cffunction>
+
+
+  <!---
+    Given a configElement type and name, returns the *first* XML text value. This assumes there is only one such element
+   --->
+  <cffunction name="getConfigElementValue" access="remote" output="false" returntype="String" hint="Given a type and name, returns the first matching XML element value.">
+    <cfargument name="type" type="string" required="true" />
+    <cfargument name="name" type="string" required="true" />
+    <cfset var element = xmlSearch(this.configXml,"/mxunit-config/config-element[@type='#arguments.type#' and @name='#arguments.name#']") />
+    <cfreturn element[1].xmlAttributes["value"] />
+  </cffunction>
+
+
+  <cffunction name="getConfigElements" access="remote" output="false" returntype="array" hint="Given an XPath expression, return an array of matching config elements">
+    <cfargument name="xpath" type="string" required="true" />
+	<cfset var elements= "">
+    <cfoutput>#arguments.xpath#</cfoutput>
+    <cfset elements = xmlSearch(this.configXml,"#arguments.xpath#") />
+    <cfreturn elements />
+  </cffunction>
+
+  <cffunction name="getConfigElementAttributeCollection" access="remote" output="false" returntype="any" hint="Given a type and name, returns all of the attributes in a struct, omitting the type and name.">
+    <cfargument name="type" type="string" required="true" />
+    <cfargument name="name" type="string" required="true" />
+    <cfset var element = xmlSearch(this.configXml,"/mxunit-config/config-element[@type='#arguments.type#' and @name='#arguments.name#']") />
+	<cfset var attribs = element[1].xmlAttributes />
+	<cfset structDelete(attribs,"name") />
+	<cfset structDelete(attribs,"type") />
+    <cfreturn attribs />
+  </cffunction>
+
+</cfcomponent>

--- a/system/compat/framework/RemoteFacade.cfc
+++ b/system/compat/framework/RemoteFacade.cfc
@@ -1,0 +1,252 @@
+<cfcomponent name="mxunit.framework.RemoteFacade" hint="Main default interface into MXUnit framework from the MXUnit Ecplise Plugin." wsversion="1">
+
+	<cfset cu = createObject("component","mxunit.framework.ComponentUtils")>
+	<cfset cache = createObject("component","mxunit.framework.RemoteFacadeObjectCache")>
+	<cfset ConfigManager = createObject("component","mxunit.framework.ConfigManager")>
+
+	<cffunction name="ping" output="false" access="remote" returntype="boolean" hint="returns true">
+		<cfreturn true>
+	</cffunction>
+
+	<cffunction name="initializeSuitePool" access="remote" returntype="void">
+		<cfset cache.initializeSuitePool()>
+	</cffunction>
+
+	<cffunction name="purgeSuitePool" access="remote" returntype="numeric">
+		<cfreturn cache.purgeSuitePool()>
+	</cffunction>
+
+	<cffunction name="getServerType" output="false" access="remote" returntype="String" hint="returns the server type, whether coldfusion or bluedragon">
+		<cfreturn server.ColdFusion.ProductName>
+	</cffunction>
+
+	<cffunction name="getFrameworkVersion" output="false" access="remote" returntype="String" hint="returns the current framework version in form of major.minor.buildnum">
+		<cfreturn "2.4.0" />
+	</cffunction>
+
+	<cffunction name="getFrameworkDate" output="false" access="remote" returntype="Date" hint="returns the current framework version date in form of mm/dd/yyyy">
+		<cfreturn now() />
+	</cffunction>
+
+	<cffunction name="startTestRun" access="remote" returntype="string">
+		<cfset var useCache = false>
+		<cfset ConfigManager.ConfigManager()>
+		<cfset useCache = configManager.getConfigElementValue("pluginControl","UseRemoteFacadeObjectCache")>
+
+		<cfif useCache>
+			<cfreturn cache.startTestRun()>
+		<cfelse>
+			<cfreturn "">
+		</cfif>
+
+	</cffunction>
+
+	<cffunction name="getObject" access="package" returntype="any">
+		<cfargument name="componentName" type="String" required="true">
+		<cfargument name="testRunKey" type="string" required="true" hint="the key returned from startTestRun; used for managing the pool of components">
+		<cfreturn cache.getObject(componentName, testRunKey)>
+	</cffunction>
+
+	<cffunction name="endTestRun" access="remote" returntype="string" hint="ensures proper cleanup">
+		<cfargument name="TestRunKey" type="string" required="true" hint="the key returned from startTestRun; used for managing the pool of components">
+
+		<!---run all components' afterTests() --->
+		<cfset var pool = cache.getSuitePool()>
+		<cfset var componentName = "">
+		<cfset var testCase = "">
+
+		<cfif structKeyExists( pool, testRunKey )>
+			<cfloop collection="#pool[testRunKey].components#" item="componentName">
+				<cftry>
+					<cfset testCase = pool[testRunKey].components[componentName]>
+					<cfset testCase.enableAfterTests()>
+					<cfset testCase.afterTests()>
+
+				<cfcatch>
+					<cflog text="MXUnit afterTests() Exception from Eclipse Remote Facade. Component Name: #componentName#. Error: #cfcatch.message#; #cfcatch.detail#">
+				</cfcatch>
+				</cftry>
+			</cfloop>
+		</cfif>
+		<cfreturn cache.endTestRun(TestRunKey)>
+	</cffunction>
+
+	<cffunction name="executeTestCase" access="remote" returntype="struct">
+		<cfargument name="componentName" type="String" required="true">
+		<cfargument name="methodNames" type="String" required="true" hint="pass empty string to run all methods. pass list of valid method names to run individual methods">
+		<cfargument name="TestRunKey" type="string" required="true" hint="the key returned from startTestRun; used for managing the pool of components">
+		<cfset var s_results = structNew()>
+		<cfset var key = "">
+		<cfset var suite = createObject("component","mxunit.framework.TestSuite").testSuite()>
+		<cfset var testResult = "">
+		<!--- the "baseTarget" is the actual test case, underneath its layers of test decorators. When we start the test case, we want the pure object, not the decorated object --->
+		<cfset var obj = getObject(componentName, TestRunKey).getBaseTarget()>
+		<cfset var componentPath = getMetadata(obj).path>
+		<cfif NOT structKeyExists(request,"debugBuffer")>
+			<cfset request.debugBuffer = [] />
+		</cfif>
+		<cfset request.debug = requestDebugFunction />
+
+		<cfset actOnTestCase(obj)>
+
+		<!--- disable afterTests... we'll run them all during endTestRun --->
+<!---
+		<cfset obj.disableAfterTests()>
+ --->
+
+		<cfif len(methodNames)>
+			<cfset suite.add(componentName, methodNames, obj)>
+		 <cfelse>
+			<cfset suite.addAll(componentName, obj)>
+		</cfif>
+		<cfset testResult = suite.run()>
+		<cfset s_results = testResultToStructs(methodNames,testResult.getResults(), componentPath)>
+		<cfreturn s_results>
+	</cffunction>
+
+	<cffunction name="requestDebugFunction">
+		<cfargument name="var" />
+		<cfset arrayAppend( request.debugBuffer, duplicate(arguments.var) ) />
+	</cffunction>
+
+	<cffunction name="getComponentMethods" access="remote" returntype="array">
+		<cfargument name="componentName" required="true" type="string" hint="">
+		<cfset var methods = arrayNew(1)>
+		<cfset var obj = "">
+		<!--- by doing this instead of letting it throw an error
+		we ensure that the error (most likely a parse error)
+		continues to show up when they run the test.  --->
+		<cftry>
+			<cfset obj = createObject("component", ComponentName).TestCase()>
+			<cfset methods = obj.getRunnableMethods()>
+		<cfcatch>
+			<cfset ArrayAppend(methods, listLast(arguments.ComponentName, ".") & " <ERROR: #cfcatch.Message#>")>
+		</cfcatch>
+		</cftry>
+
+		<cfreturn methods>
+	</cffunction>
+
+
+<!---	<cffunction name="getComponentMethodsRich2" access="remote" returntype="array">
+		<cfset var bean = {dataprovidertype="excel", rows=50}>
+		<cfreturn [bean]>
+	</cffunction>--->
+
+	<cffunction name="actOnTestCase" access="public" hint="an 'Interceptor' for custom remote facades. This will enable you to act on each test case object, possibly injecting additional data, etc" output="false">
+		<cfargument name="testCase" required="true" hint="">
+
+	</cffunction>
+
+	<cffunction name="testResultToStructs" hint="turns the TestResult item into a struct for passing to eclipse. It will only ever process a single component under test, although I did build it to loop over the array of tests returned from the TestResult, although currently there is no condition under which that will ever be more than a single-element array" access="public">
+		<cfargument name="methodNames" required="true">
+		<cfargument name="testResult" required="true">
+		<cfargument name="componentPath" required="true" hint="the full filesystem path to the component under test">
+
+		<cfset var bundleStats = testResult.getBundleStats() />
+		<cfset var s_results = structNew()>
+		<cfset var s_test = structNew()>
+		<cfset var test = 1>
+		<cfset var tag = 1>
+		<cfset var i = 1>
+		<cfset var t = "">
+		<cfset var iDebug = 1>
+		<cfset var debugString = "">
+		<cfset var isFrameworkTest = cu.isFrameworkTemplate(ComponentPath)>
+    <cfif arrayLen(bundleStats[1].suiteStats)>
+  		<cfset var a_tests = bundleStats[1].suiteStats[1].specStats>
+    <cfelse>
+      <cfset s_test = {name=listFirst(methodNames),status="failure",totalduration=0,failmessage="fail",failorigin="here",error=bundleStats[1].GLOBALEXCEPTION}>
+      <cfset a_tests[1] = s_test />
+    </cfif>
+		<cfif ArrayLen(bundleStats[1].debugbuffer)>
+			<cfsavecontent variable="debugString">
+				<cfloop from="1" to="#ArrayLen(request.debugbuffer)#" index="iDebug">
+					<cfdump var="#request.debugbuffer[iDebug]#">
+				</cfloop>
+				<cfloop from="1" to="#ArrayLen(bundleStats[1].debugbuffer)#" index="iDebug">
+					<cfdump var="#bundleStats[1].debugbuffer[iDebug]#">
+				</cfloop>
+			</cfsavecontent>
+		<cfelseif ArrayLen(request.debugbuffer)>
+			<cfsavecontent variable="debugString">
+				<cfloop from="1" to="#ArrayLen(request.debugbuffer)#" index="iDebug">
+					<cfdump var="#request.debugbuffer[iDebug]#">
+				</cfloop>
+			</cfsavecontent>
+		<cfelse>
+			<cfset debugString = "<p class='nodebugresults'>No calls made to debug().</p> ">
+		</cfif>
+
+		<cfloop from="1" to="#ArrayLen(a_tests)#" index="test">
+			<cfset s_test = a_tests[test]>
+			<cfif not StructKeyExists(s_results,bundleStats[1].path)>
+				<cfset s_results[bundleStats[1].path] = structNew()>
+			</cfif>
+			<cfset s_results[bundleStats[1].path][s_test.name] = structNew()>
+
+			<cfset t = s_results[bundleStats[1].path][s_test.name]>
+
+			<cfset t.OUTPUT = debugString>
+			<cfset t.MESSAGE = "">
+			<cfset t.RESULT = s_test.status>
+			<cfset t.TIME = javacast("int",s_test.totalduration)>
+			<cfset t.EXPECTED = "">
+			<cfset t.ACTUAL = s_test.FAILMESSAGE>
+			<!--- <cfset t.httprequestdata = getHTTPRequestData()> --->
+			<cfif isArray(s_test.FAILORIGIN) && arrayLen(s_test.FAILORIGIN)>
+				<cfset t.EXCEPTION = formatExceptionKey(s_test.FAILORIGIN[1].type)>
+				<cfset t.MESSAGE = s_test.failmessage>
+				<!--- <cfset t.TagContext = s_test.error.tagcontext>	 --->
+				<cfset t.TAGCONTEXT = ArrayNew(1)>
+				<cfset i = 1>
+				<cfloop from="1" to="#ArrayLen(s_test.failorigin)#" index="tag">
+					<cfif FileExists(s_test.failorigin[tag].template)>
+						<!---<cflog text=" #s_test.error.tagcontext[tag].template# #isFrameworkTest# OR NOT #cu.isFrameworkTemplate(s_test.error.tagcontext[tag].template)#" >--->
+						<cfif isFrameworkTest OR NOT cu.isFrameworkTemplate(s_test.failorigin[tag].template)>
+							<cfset t.TAGCONTEXT[i] = structNew()>
+							<cfset t.TAGCONTEXT[i].FILE = s_test.failorigin[tag].template>
+							<cfset t.TAGCONTEXT[i].LINE = javacast("int",s_test.failorigin[tag].line)>
+							<cfset i = i + 1>
+						</cfif>
+					</cfif>
+				</cfloop>
+			</cfif>
+			<cfif structKeyList(s_test.error) NEQ "">
+				<cfset t.EXCEPTION = formatExceptionKey(s_test.error.type)>
+				<cfset t.MESSAGE = s_test.error.message>
+				<cfif len(s_test.error.detail)>
+					<cfset t.MESSAGE = t.MESSAGE & " " & s_test.error.detail>
+				</cfif>
+				<!--- <cfset t.TagContext = s_test.error.tagcontext>	 --->
+				<cfset t.TAGCONTEXT = ArrayNew(1)>
+				<cfset i = 1>
+					<!---		 --->
+				<cfloop from="1" to="#ArrayLen(s_test.error.tagcontext)#" index="tag">
+					<cfif FileExists(s_test.error.tagcontext[tag].template)>
+						<!---<cflog text=" #s_test.error.tagcontext[tag].template# #isFrameworkTest# OR NOT #cu.isFrameworkTemplate(s_test.error.tagcontext[tag].template)#" >--->
+						<cfif isFrameworkTest OR NOT cu.isFrameworkTemplate(s_test.error.tagcontext[tag].template)>
+							<cfset t.TAGCONTEXT[i] = structNew()>
+							<cfset t.TAGCONTEXT[i].FILE = s_test.error.tagcontext[tag].template>
+							<cfset t.TAGCONTEXT[i].LINE = javacast("int",s_test.error.tagcontext[tag].line)>
+							<cfset i = i + 1>
+						</cfif>
+					</cfif>
+				</cfloop>
+			</cfif>
+		</cfloop>
+
+		<cfreturn s_results>
+	</cffunction>
+
+	<cffunction name="formatExceptionKey" access="package" hint="ensures a string in the EXCEPTION key. This is necessitated by a weirdo bug in CF with NonArrayExceptions" returntype="string">
+		<cfargument name="ErrorType" required="true" type="any" hint="the TYPE key from the cfcatch struct">
+
+		<cfif isSimpleValue(ErrorType)>
+			<cfreturn ErrorType>
+		<cfelse>
+			<cfreturn "Exception[ComplexValue]: " & ErrorType.toString()>
+		</cfif>
+	</cffunction>
+
+</cfcomponent>

--- a/system/compat/framework/RemoteFacadeObjectCache.cfc
+++ b/system/compat/framework/RemoteFacadeObjectCache.cfc
@@ -1,0 +1,104 @@
+<cfcomponent hint="Mechanism for managing a cache of objects. This is nice to have since the remote facade runs its tests method-at-a-time. Without a cache, you'd incur all the overhead of constructing the Test object(s) multiple times, which is not ideal.">
+
+	<cfset storageScope = "server">
+	<cfset initializeSuitePool()>
+
+	<cffunction name="initializeSuitePool" access="public" returntype="struct">
+		<cfreturn structGet("#storageScope#.MXUnitRemoteTestSuites")>
+	</cffunction>
+
+	<cffunction name="getSuitePool" access="public" hint="returns the pool struct" returntype="struct">
+		<!--- THIS IS TEMPORARY!!! keeping this here until the structget bug is fixed in railo; then, revert to:
+
+		<cfreturn initializeSuitePool()>
+
+		 --->
+		<cfreturn server.MXUnitRemoteTestSuites>
+	</cffunction>
+
+	<cffunction name="getSuitePoolCount" access="public" returntype="numeric" hint="returns the number of TestRun items in the pool">
+		<cfreturn StructCount(getSuitePool())>
+	</cffunction>
+
+	<cffunction name="PurgeSuitePool" access="public" returntype="numeric">
+		<cfset StructClear(getSuitePool())>
+		<cfreturn getSuitePoolCount()>
+	</cffunction>
+
+	<cffunction name="startTestRun" access="public" returntype="string">
+		<cfset var TestRunKey = createUUID()>
+		<cfset initializeTestRunCache(TestRunKey)>
+		<cflog file="mxunit" text="Initializing cache with key #TestRunKey#">
+		<cfreturn TestRunKey>
+	</cffunction>
+
+	<cffunction name="initializeTestRunCache" access="private">
+		<cfargument name="TestRunKey" type="string" required="true" hint="the key returned from startTestRun; used for managing the pool of components">
+
+		<cfset var thisRun = StructNew()>
+		<cfset thisRun.Components = StructNew()>
+		<cfset thisRun.StartTime = now()>
+		<cfset thisRun.LastAccessed = now()>
+		<cfset StructInsert(getSuitePool(),TestRunKey,thisRun)>
+
+		<cflog file="mxunit" text="Initialized TestRun with key #TestRunKey#">
+	</cffunction>
+
+	<cffunction name="getObject" access="public" returntype="any">
+		<cfargument name="componentName" type="String" required="true">
+		<cfargument name="TestRunKey" type="string" required="true" hint="the key returned from startTestRun; used for managing the pool of components">
+		<cfset var obj = "">
+		<cfset var pool = getSuitePool()>
+		<cfif len(TestRunKey)>
+			<!--- could only ever happen if a purgeStaleTests() hit from a separate eclipse process while another TestRun was very long running. See explanation in the purgeStaleTests method --->
+			<cfif NOT StructKeyExists(pool,TestRunKey)>
+				<cfset initializeTestRunCache(TestRunKey)>
+			</cfif>
+
+			<cfif NOT StructKeyExists(pool[TestRunKey].Components,componentName)>
+				<cfset pool[TestRunKey].Components[componentName] = createObject("component", componentName).TestCase()>
+				<!---  <cflog file="mxunit" text="key is #TestRunKey#; component is #componentName#">  --->
+			</cfif>
+			<cfset obj = pool[TestRunKey].Components[componentName]>
+			<cfset pool[TestRunKey].LastAccessed = now()>
+		<cfelse>
+			<cfset obj = createObject("component", componentName).init()>
+		</cfif>
+		<cfreturn obj>
+	</cffunction>
+
+	<cffunction name="endTestRun" access="public" returntype="string" hint="ensures proper cleanup">
+		<cfargument name="TestRunKey" type="string" required="true" hint="the key returned from startTestRun; used for managing the pool of components">
+		<cfset var initialCount = getSuitePoolCount()>
+		<cfset StructDelete(getSuitePool(),TestRunKey)>
+		<cflog file="mxunit" text="RemoteSuiteCount: initial #initialCount#; now: #getSuitePoolCount()#">
+		<cfset purgeStaleTests()>
+
+		<cfreturn "">
+	</cffunction>
+
+	<cffunction name="purgeStaleTests" access="public" returntype="numeric" hint="cleans up long-running tests. This is simply overwrought prudence to ensure that very anomalous behavior doesn't result in a build-up of cruft in the server scope. The remote facade is designed to run start, execute, and cleanup independently of one another precisely to prevent catastrophic test errors from leaving a dirty cache. But one never knows what might happen">
+		<cfargument name="NumMinutes" type="numeric" required="false" default="10" hint="Number of minutes a TestRun (which comprises multiple objects potentially) can remain in the cache after its LastAccessed value">
+		<!--- now let's think about this: in order for a TestRun to go unaccessed for this long, a single test method would have to take this long, and
+		some other mxunit plugin process would need to be running from within eclipse and execute tests on the same server. This would happen in an
+		environment where a shared server is used and multiple people are running tests from within eclipse against that server (like a dev server). In this
+		unlikely event where you have a test that runs this long, the effect of removing an object from the cache is that, on the next method run for
+		the same test key, the cache for that key would simply be recreated --->
+		<cfset var TestRun = "">
+		<cfset var compareTime = now()>
+		<cfset var lastAccessed = "">
+		<cfset var purged = 0>
+		<cfset var pool = getSuitePool()>
+		<cfloop collection="#pool#" item="TestRun">
+			<cfset lastAccessed = pool[TestRun].LastAccessed>
+			<cfif DateDiff("n",lastAccessed,compareTime) GT NumMinutes>
+				<cfset StructDelete(pool,TestRun)>
+				<cfset purged = purged + 1>
+				<cflog file="mxunit" text="Removing TestSuite with key #TestRun# from object cache. Last Accessed at #lastAccessed#">
+			</cfif>
+		</cfloop>
+		<cfreturn purged>
+	</cffunction>
+
+
+</cfcomponent>

--- a/system/compat/framework/Results.cfc
+++ b/system/compat/framework/Results.cfc
@@ -3,7 +3,7 @@
 * www.ortussolutions.com
 * ---
 * A compat class for MXUnit Directory Test Suite
-*/ 
+*/
 component{
 
 	/**
@@ -11,18 +11,18 @@ component{
 	* @bundles
 	* @testSpecs
 	*/
-	function init( 
+	function init(
 		required bundles,
 		testSpecs=""
 	){
-	
+
 		for( var thisArg in arguments ){
 			variables[ thisArg ] = arguments[ thisArg ];
-		}	
-			
+		}
+
 		return this;
-	}	
-	
+	}
+
 	/**
 	* Get the results output in a specific mode
 	* @mode The mode of the output
@@ -30,15 +30,21 @@ component{
 	any function getResultsOutput( mode="simple" ){
 
 		switch( arguments.mode ){
-			case "junitxml" : { arguments.mode = "junit"; break; } 
+			case "junitxml" : { arguments.mode = "junit"; break; }
 			case "query" 	: case "array" 		: { arguments.mode = "raw"; break; }
 			case "html" 	: case "rawhtml" 	: { arguments.mode = "simple"; break; }
 			default 		: { arguments.mode = "simple"; }
 		}
 
 		var tb = new testbox.system.TestBox( bundles=variables.bundles );
-		
+
 		return tb.run( testSpecs=variables.testSpecs, reporter=arguments.mode );
 	}
+
+  any function getResults(){
+    var tb = new testbox.system.TestBox( bundles=variables.bundles );
+    return tb.runRaw(testSpecs=variables.testSpecs);
+    
+  }
 
 }

--- a/system/compat/framework/TestSuite.cfc
+++ b/system/compat/framework/TestSuite.cfc
@@ -8,13 +8,16 @@ component accessors="true"{
 
 	property name="bundles";
 	property name="testSpecs";
-	
+
 	// constructor
 	function testSuite(){
 		variables.bundles 	= [];
 		variables.testSpecs = [];
-		
 		return this;
+	}
+	// constructor
+	function init(){
+		return testSuite();
 	}
 
 	remote function addTest( required componentName, required method ){
@@ -22,15 +25,15 @@ component accessors="true"{
 		variables.testSpecs.addAll( listToArray( arguments.method ) );
 		return this;
 	}
-	
+
 	remote function add( required componentName, required methods ){
 		arrayAppend( variables.bundles, arguments.componentName );
 		variables.testSpecs.addAll( listToArray( arguments.methods ) );
 		return this;
 	}
-	
+
 	remote function addAll( required componentName ){
-		arrayAppend( variables.bundles, arguments.componentName );	
+		arrayAppend( variables.bundles, arguments.componentName );
 		return this;
 	}
 

--- a/system/compat/framework/mxunit-config.xml
+++ b/system/compat/framework/mxunit-config.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" ?> 
+ <mxunit-config>
+  <config-element type="meta" name="version" value="1.0.0" /> 
+  
+  <!-- 
+  Tells MXUnit how the framework should be mapped. MXUnit attempts to discover
+  this, but, in some configurations, this does not work. So, specify the
+  dotted notation where mxunit is installed. 
+  
+  *The "override" attribute tells mxunit to 
+  
+  Examples:
+  1. Mapped or installed directly under webroot: mxunit [Default]
+  2. Mapped or installed in a subdirectory under webroot: mysubdirectory.mxunit
+  --> 
+  <config-element type="userConfig" name="componentRoot" value="mxunit" override="false" /> 
+
+
+  <!-- 
+  Assertion extensions. Enable or disable auto-loading at runtime.
+  Alternatively, you can load Assertion extensions in your test case
+  setUp() method by invoking Assert.addAssertDecorator(MyCustomAssertion).
+  The override parameter tells the framework to override any duplicate assertions
+  with the ones in the custom assertion.
+   --> 
+  <config-element type="assertionExtension" path="MXUnitAssertionExtensions" autoload="true" override="false" /> 
+  <config-element type="assertionExtension" path="HamcrestAssert" autoload="true" override="false" />
+  <config-element type="assertionExtension" path="XPathAssert" autoload="true" override="false" />
+  
+  <!--
+  <config-element type="assertionExtension" path="org.cfcunit.framework.Assert" autoload="true" override="false" /> 
+  <config-element type="assertionExtension" path="net.sourceforge.cfunit.framework.Assert" autoload="false" override="false" />
+  -->
+    
+  
+  <!-- 
+  Tells the MXUnit Eclipse plug-in to automatically cache
+  test object to increase performance. Change element value to false
+  to override.
+  --> 
+  <config-element type="pluginControl" name="UseRemoteFacadeObjectCache" value="true" /> 
+
+
+  <!-- 
+   Tells the MXUnit framework how to execute assertions. If set to false, message parameter
+  in assertions is optional but should be last of used; E.g., assertEquals(expected, actual [,message]).
+  If set to true, follows the JUnit parameter syntax but the first parameter is REQUIRED; E.g., 
+  assertEquals(message, expected, actual). The default is false.
+   --> 
+  <config-element type="assertionMessageBehavior" name="MessageParameterFirst" value="false" /> 
+
+
+  <!-- 
+  Which mocking framework should be used?
+  -->
+  <config-element type="mockingFramework" name="name" value="MightyMock" /> 
+
+  <!-- 
+  Configuration for MightyMock
+  factoryPath: path to the MockFactory object
+  createMockMethodName: the name of the default method in the MockFactory to use for creating mocks
+  createMockStringArgumentName: the name of the string argument to the createMockMethod that holds the path of the object to be mocked
+  createMockObjectArgumentName: the name of the object argument to the createMockMethod that holds an actual object to be mocked
+  constructorName: the name of the constructor method on the MockFactory
+  constructorArgs: one attribute per argument expected by the MockFactory constructor
+  -->
+  <config-element type="MightyMock" name="factoryPath" value="mightymock.MockFactory" /> 
+  <config-element type="MightyMock" name="createMockMethodName" value="createMock" /> 
+  <config-element type="MightyMock" name="createMockStringArgumentName" value="mocked" /> 
+  <config-element type="MightyMock" name="createMockObjectArgumentName" value="mocked" /> 
+  <config-element type="MightyMock" name="constructorName" value="init" /> 
+  <config-element type="MightyMock" name="constructorArgs" /> 
+    
+  <!-- 
+  Configuration for MockBox
+  -->
+  <config-element type="MockBox" name="factoryPath" value="Coldbox.system.testing.MockBox" /> 
+  <config-element type="MockBox" name="createMockMethodName" value="createMock" /> 
+  <config-element type="MockBox" name="createMockStringArgumentName" value="className" /> 
+  <config-element type="MockBox" name="createMockObjectArgumentName" value="object" /> 
+  <config-element type="MockBox" name="constructorName" value="init" /> 
+  <config-element type="MockBox" name="constructorArgs" generationPath="/Coldbox/Temp/" /> 
+
+  <!-- 
+  Configuration for ColdMock
+  -->
+  <config-element type="ColdMock" name="factoryPath" value="coldmock.MockFactory" /> 
+  <config-element type="ColdMock" name="createMockMethodName" value="createMock" /> 
+  <config-element type="ColdMock" name="createMockStringArgumentName" value="objectToMock" /> 
+  <config-element type="ColdMock" name="createMockObjectArgumentName" value="notApplicable" /> 
+  <config-element type="ColdMock" name="constructorName" value="init" /> 
+  <config-element type="ColdMock" name="constructorArgs" /> 
+
+  <!-- 
+  Configuration for another framework - example of adding your own plugin
+  -->
+  <config-element type="newFramework" name="factoryPath" value="mxunit.tests.framework.fixture.MockFactory" /> 
+  <config-element type="newFramework" name="createMockMethodName" value="createMeAMock" /> 
+  <config-element type="newFramework" name="createMockStringArgumentName" value="componentName" /> 
+  <config-element type="newFramework" name="createMockObjectArgumentName" value="object" /> 
+  <config-element type="newFramework" name="constructorName" value="initMethod" /> 
+  <config-element type="newFramework" name="constructorArgs" arg1="constructorArg1" /> 
+
+
+ </mxunit-config>

--- a/system/runners/BaseRunner.cfc
+++ b/system/runners/BaseRunner.cfc
@@ -132,8 +132,12 @@ component{
 	* @target.hint The target object
 	*/
 	boolean function isValidTestMethod( required methodName, required target ) {
-		// True if annotation "test" exists
-		if( structKeyExists( getMetadata( arguments.target[ arguments.methodName ] ), "test" ) ){
+		var md = getMetadata( arguments.target);
+		// MXUnit does not require "test" to be in the function name
+		if( structKeyExists( md, "extends" ) && md.extends.name == "mxunit.framework.TestCase"){
+			return true;
+		}
+		if( structKeyExists( md[ arguments.methodName ], "test" ) ){
 			return true;
 		}
 		// All xUnit test methods must start or end with the term, "test". 


### PR DESCRIPTION
This fleshes out MXUnit compatibility, which allows folks to use the MXUnit Eclipse plugin.  Besides adding the stuff needed for RemoteFacade, it also tweaks BaseRunner-- MXUnit doesn't require tests to have "test" in their function names, so this tweak runs those tests while in mxunit compatibility mode instead of silently skipping them.
