### PR TITLE
ACF Compatibility for properties file write

### DIFF
--- a/system/runners/HTMLRunner.cfm
+++ b/system/runners/HTMLRunner.cfm
@@ -44,6 +44,10 @@ total.fail=#testResult.getTotalFail()#
 total.error=#testResult.getTotalError()#
 total.skipped=#testResult.getTotalSkipped()#" );
 	}
+	
+	//ACF Compatibility - check for and expand to absolute path
+	if( !directoryExists( url.reportpath ) ) url.reportpath = expandPath( url.reportpath );
+	
 	fileWrite( url.reportpath & "/" & url.propertiesFilename, propertiesReport );
 }
 


### PR DESCRIPTION
ACF requires an absolute drive path for fileWrite:

http://help.adobe.com/en_US/ColdFusion/9.0/CFMLRef/WSc3ff6d0ea77859461172e0811cbec22c24-6cdf.html

```
If not an absolute path (starting with a drive letter and a colon, or a forward or backward slash), it is relative to the ColdFusion temporary directory, which is returned by the GetTempDirectory function.
```