### PR TITLE
Fix minor issues when setting up TestBox with CF10

### DIFF
--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -11,7 +11,7 @@ component{
 	// any mappings go here, we create one that points to the root called test.
 	this.mappings[ "/tests" ] = getDirectoryFromPath( getCurrentTemplatePath() );
 	// Map back to its root
-	rootPath = REReplaceNoCase( this.mappings[ "/tests" ], "tests(\\|/)", "" );
+	rootPath = REReplaceNoCase( this.mappings[ "/tests" ], "tests(\\|/)$", "" );
 	this.mappings[ "/testbox" ] = rootPath;
 	// Map resources
 	this.mappings[ "/coldbox" ] = this.mappings[ "/tests" ] & "resources/coldbox";

--- a/tests/specs/BDDLifecycleAnnotationsTest.cfc
+++ b/tests/specs/BDDLifecycleAnnotationsTest.cfc
@@ -34,7 +34,7 @@ component extends="tests.utils.ExampleParentTestCase"{
             describe( "Lifecycle Annotation Hooks with normal Lifecycle Methods", function() {
                 beforeEach(function() {
                     variables.counter++;
-                })
+                });
 
                 it("runs both types of methods", function() {
                     expect( variables.counter ).toBe( 8 );

--- a/tests/specs/mockbox/MockBoxTest.cfc
+++ b/tests/specs/mockbox/MockBoxTest.cfc
@@ -335,11 +335,11 @@
 				);
 
 			$assert.notThrows(
-				target = function() { mocked.dontPassThrowToMe() }
+				target = function() { mocked.dontPassThrowToMe(); }
 			);
 
 			$assert.throws(
-				target = function() { mocked.dontPassThrowToMe( "throw" ) },
+				target = function() { mocked.dontPassThrowToMe( "throw" ); },
 				type = "MyCustomException",
 				message = "My Custom Exception Message"
 			);


### PR DESCRIPTION
The following minor fixes were need so TestBox run cleanly in our environment.

- The first fix was to add semi-colons in two different test suites.  I assume this is due to our CF10 settings being more strict than Lucee. 
- The second fix is in the Application.cfc.  I installed TestBox in a subdirectory called `C:\somedirectory\UnitTests\testbox`.  The Regex replaced all instances of `tests` which caused the rootpath to be set to `C:\somedirectory\Unittestbox\testbox`.  This caused MockBox to use an invalid directory and throw errors.