### PR TITLE
TESTBOX-174 add expectAll() convenience for collections

### DIFF
--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -429,6 +429,16 @@ component{
 		return oExpectation;
 	}
 
+    /**
+    * Start a collection expectation expression. This returns an instance of CollectionExpection
+    * so you can work with its collection-unrolling matches (delegating to Expection).
+    * @actual The actual value, it should be an array or a struct.
+    */
+    CollectionExpectation function expectAll( required any actual ){
+        var cExpectation = new CollectionExpectation( spec=this, assertions=this.$assert, collection=arguments.actual );
+        return cExpectation;
+    }
+
 	/**
 	* Add custom matchers to your expectations
 	* @matchers The structure of custom matcher functions to register or a path or instance of a CFC containing all the matcher functions to register

--- a/system/CollectionExpectation.cfc
+++ b/system/CollectionExpectation.cfc
@@ -1,0 +1,38 @@
+/**
+ * Copyright Since 2005 TestBox Framework by Luis Majano and Ortus Solutions, Corp
+ * www.ortussolutions.com
+ * ---
+ * The CollectionExpectation CFC holds a collection and behaves like an expectation
+ * that automatically unrolls the collection to verify every element
+ */
+component accessors="true"{
+
+    // The (actual) collection
+    property name="actual";
+    // The reference to the spec that created this
+    property name="spec";
+    // The assertions reference
+    property name="assert";
+
+    function init( required spec, required any assertions, required collection ){
+        variables.actual = arguments.collection;
+        variables.spec   = arguments.spec;
+        variables.assert = arguments.assertions;
+    }
+
+    function onMissingMethod( string missingMethodName, any missingMethodArguments ){
+        if( isArray( variables.actual ) ){
+            for ( var e in variables.actual ){
+                evaluate( "variables.spec.expect( e ).#missingMethodName#( argumentCollection=missingMethodArguments )" );
+            }
+        } else if( isStruct( variables.actual ) ){
+            for ( var k in variables.actual ){
+                var e = variables.actual[k];
+                evaluate( "variables.spec.expect( e ).#missingMethodName#( argumentCollection=missingMethodArguments )" );
+            }
+        } else {
+            variables.assert.fail( "expectAll() actual is neither array nor struct" );
+        }
+        return this; // so we can chain matchers
+    }
+}

--- a/tests/specs/BDDTest.cfc
+++ b/tests/specs/BDDTest.cfc
@@ -132,6 +132,25 @@ component extends="testbox.system.BaseSpec"{
 				expect( 10 ).toBeLTE( 10 );
 			});
 
+            it( "can test a collection", function(){
+                expectAll( [2,4,6,8] ).toSatisfy( function(x){ return 0 == x%2; });
+                expectAll( {a:2,b:4,c:6} ).toSatisfy( function(x){ return 0 == x%2; });
+                // and we can chain matchers
+                expectAll( [2,4,6,8] )
+                    .toBeGTE( 2 )
+                    .toBeLTE( 8 );
+            });
+
+            it( "can fail any element of a collection", function() {
+                try{
+                    // we need to verify the expectation fails
+                    expectAll( [2,4,10,8] ).toBeLT( 10 );
+                    fail( "expectAll() failed to detect a bad element" );
+                }catch( any e ){
+                    expect( e.message ).toBe( "The actual [10] is not less than [10]" );
+                }
+            });
+
 		});
 
 		// Custom Matchers


### PR DESCRIPTION
Adds `expectAll()` which returns a `CollectionExpectation` that knows how to delegate all methods to `Expectation`, unrolling the array or struct so the expectation applies to each element.