### PR TITLE
fix bug in Assertion.throws()

### DIFF
--- a/system/Assertion.cfc
+++ b/system/Assertion.cfc
@@ -372,18 +372,14 @@ component{
 			// If no type, message expectations, just throw flag
 			if( !len( arguments.type ) && arguments.regex eq ".*" ){ return this; }
 
-			// Type expectation + message regex, do match no case to account for empty messages
-			if( len( arguments.type ) &&
-				e.type eq arguments.type &&
-				( arrayLen( reMatchNoCase( arguments.regex, e.message ) ) OR arrayLen( reMatchNoCase( arguments.regex, e.detail ) ) )
-			){
-				return this;
-			}
+			// determine if the expected 'type' matches the actual exception 'type'
+			var typeMatches = len( arguments.type ) == 0 OR e.type eq arguments.type;
 
-			// Message+Detail regex then only
-			if( arguments.regex neq ".*" &&
-				( arrayLen( reMatchNoCase( arguments.regex, e.message ) ) OR arrayLen( reMatchNoCase( arguments.regex, e.detail ) ) )
-			){
+			// determine if the expected 'regex' matches the actual exception 'message' or 'detail'
+			var regexMatches = arguments.regex eq ".*" OR ( arrayLen( reMatchNoCase( arguments.regex, e.message ) ) OR arrayLen( reMatchNoCase( arguments.regex, e.detail ) ) );
+
+			// this assertion passes if the expected type and regex match the actual exception data
+			if( typeMatches && regexMatches ){
 				return this;
 			}
 

--- a/tests/specs/AssertionsTest.cfc
+++ b/tests/specs/AssertionsTest.cfc
@@ -31,6 +31,24 @@ component displayName="TestBox xUnit suite for cf10 and above" labels="lucee,cf"
 		});
 	}
 
+	function testThrowsDoesNotIgnoreTypeWhenRegexMatches(){
+		var message = "exception_message";
+
+		var target = function() {
+			throw(type="actual_type", message=message);
+		};
+
+		var assertionFailed = false;
+
+		try {
+			$assert.throws(target=target, type="expected_type", regex=message); // regex matches the exception message, but type does not
+		} catch (any e) {
+			assertionFailed = true;
+		}
+
+		$assert.isTrue(assertionFailed, "$assert.throws() was expected to fail because the expected type ('excpected_type') did not match the actual type ('actual_type')");
+	}
+
 	function testAwesomeCustomAssertion(){
 		$assert.isAwesome( "Luis Majano" );
 	}


### PR DESCRIPTION
the 'type' argument was being ignored if the 'regex' argument was provided and
matched the exception data