### PR TITLE
Preserve whitespace in HTML (simple) Reporter

### DIFF
--- a/system/reports/assets/css/simple.css
+++ b/system/reports/assets/css/simple.css
@@ -27,6 +27,7 @@ div.skipped{ display: none;}
 .padding0{ padding: 0px; }
 .float-right{ float: right;}
 .float-left{ float: left;}
+.preserve-whitespace { white-space: pre;}
 /** boxes **/
 .box{ border:1px solid gray; margin: 10px 0px; padding: 10px; background-color: #f5f5f5}
 .buttonBar{ float:right; margin: 10px 5px 0px 10px }

--- a/system/reports/assets/simple.cfm
+++ b/system/reports/assets/simple.cfm
@@ -189,7 +189,7 @@
 						<a href="#variables.baseURL#&testSpecs=#URLEncodedFormat( local.thisSpec.name )#&testBundles=#URLEncodedFormat( arguments.bundleStats.path )#" class="#lcase( local.thisSpec.status )#">#local.thisSpec.name# (#local.thisSpec.totalDuration# ms)</a>
 
 						<cfif local.thisSpec.status eq "failed">
-							- <strong>#htmlEditFormat( local.thisSpec.failMessage )#</strong>
+							- <strong class="preserve-whitespace">#htmlEditFormat( local.thisSpec.failMessage )#</strong>
 							  <button onclick="toggleDebug( '#local.thisSpec.id#' )" title="Show more information">+</button><br>
 							  
 							  <cfif arrayLen( local.thisSpec.failOrigin )>


### PR DESCRIPTION
Preserve whitespace in the fail message, so that it's much easier to see in the HTML runner if there is an extra space, tab or line feed which is causing the expectation to fail. 