### PR TITLE
wrap bundle runner execution in try/catch with rethrow

### DIFF
--- a/system/TestBox.cfc
+++ b/system/TestBox.cfc
@@ -402,17 +402,23 @@ component accessors="true"{
 			arguments.callbacks.onBundleStart( target, testResults );
 		}
 
-		// Discover type?
-		if( structKeyExists( target, "run" ) ){
-			// Run via BDD Style
-			new testbox.system.runners.BDDRunner( options=variables.options, testbox=this )
-				.run( target, arguments.testResults, arguments.callbacks );
+		try {		
+		
+			// Discover type?
+			if( structKeyExists( target, "run" ) ){
+				// Run via BDD Style
+				new testbox.system.runners.BDDRunner( options=variables.options, testbox=this )
+					.run( target, arguments.testResults, arguments.callbacks );
+			}
+			else{
+				// Run via xUnit Style
+				new testbox.system.runners.UnitRunner( options=variables.options,testbox=this )
+					.run( target, arguments.testResults, arguments.callbacks );
+			}	
 		}
-		else{
-			// Run via xUnit Style
-			new testbox.system.runners.UnitRunner( options=variables.options,testbox=this )
-				.run( target, arguments.testResults, arguments.callbacks );
-		}
+		catch (any ex) {
+			throw(message = "Error executing bundle - #arguments.bundlePath#  message: #ex.message#", detail = ex.stackTrace);
+		}			
 
 		// Store debug buffer for this bundle
 		arguments.testResults.storeDebugBuffer( target.getDebugBuffer() );

--- a/system/TestBox.cfc
+++ b/system/TestBox.cfc
@@ -402,7 +402,7 @@ component accessors="true"{
 			arguments.callbacks.onBundleStart( target, testResults );
 		}
 
-		try {		
+		try{
 		
 			// Discover type?
 			if( structKeyExists( target, "run" ) ){
@@ -415,10 +415,9 @@ component accessors="true"{
 				new testbox.system.runners.UnitRunner( options=variables.options,testbox=this )
 					.run( target, arguments.testResults, arguments.callbacks );
 			}	
+		} catch( Any e ){
+			throw( message="Error executing bundle - #arguments.bundlePath#  message: #e.message# #e.detail#", detail=e.stackTrace );
 		}
-		catch (any ex) {
-			throw(message = "Error executing bundle - #arguments.bundlePath#  message: #ex.message#", detail = ex.stackTrace);
-		}			
 
 		// Store debug buffer for this bundle
 		arguments.testResults.storeDebugBuffer( target.getDebugBuffer() );


### PR DESCRIPTION
An update for your consideration. While working to get our large set of MXUnit tests running under TestBox, we were running into some exceptions due to some environmental issues with our code. 

We found it helpful for debugging to wrap the runner calls inside testBundle() with a try/catch and throw a detailed exception inside.