### PR TITLE
Improved method mocking performance

### DIFF
--- a/system/MockBox.cfc
+++ b/system/MockBox.cfc
@@ -34,7 +34,7 @@ Description		:
 				instance.generationPath = instance.generationPath & "/";
 			}
 
-			instance.mockGenerator 	= createObject("component","testbox.system.mockutils.MockGenerator").init( this, true );
+			instance.mockGenerator 	= createObject("component","testbox.system.mockutils.MockGenerator").init( this, false );
 
 			return this;
 		</cfscript>
@@ -532,8 +532,8 @@ Description		:
 					serializedArgs &= toString( argOrderedTree[ arg ] );
 				}
 				else if( isObject( argOrderedTree[ arg ] ) and isInstanceOf( argOrderedTree[ arg ], "Component" ) ){
-					// If an object and CFC, just use serializeJSON
-					serializedArgs &= serializeJSON( argOrderedTree[ arg ] );
+					// If an object and CFC, get its unique identity hash code
+					serializedArgs &= getIdentityHashCode( argOrderedTree[ arg ] );
 				}
 				else{
 					// Get obj rep
@@ -599,6 +599,14 @@ Description		:
 			obj.$reset				= variables.$reset;
 			// Mock Box
 			obj.mockBox 			= this;
+		</cfscript>
+	</cffunction>
+
+	<cffunction name="getIdentityHashCode" access="private" returntype="string" output="false">
+		<cfargument name="target" type="any" required="true" />
+		<cfscript>
+			var system = createObject("java", "java.lang.System");
+			return system.identityHashCode(arguments.target);
 		</cfscript>
 	</cffunction>
 

--- a/system/mockutils/MockGenerator.cfc
+++ b/system/mockutils/MockGenerator.cfc
@@ -46,10 +46,11 @@ Description		:
 		<cfscript>
 			var udfOut  		= createObject( "java", "java.lang.StringBuilder" ).init( '' );
 			var genPath 		= expandPath( instance.mockBox.getGenerationPath() );
-			var tmpFile 		= createUUID() & ".cfm";
+			var tmpFile 		= "";
 			var fncMD 			= arguments.metadata;
 			var isReservedName 	= false;
 			var safeMethodName	= arguments.method;
+			var stubCode 		= "";
 
 			// Check reserved list and if so, rename it so we can include it, stupid CF
 			if( structKeyExists( getFunctionList(), arguments.method ) ){
@@ -155,7 +156,11 @@ Description		:
 			udfOut.append('</cffunction>');
 
 			// Write it out
-			writeStub(genPath & tmpFile, udfOUt.toString());
+			stubCode = udfOUt.toString();
+			tmpFile = hash(stubCode) & ".cfm";
+			if( !FileExists(genPath & tmpFile) ) {
+				writeStub(genPath & tmpFile, stubCode);
+			}
 
 			// Mix In Stub
 			try{
@@ -208,10 +213,11 @@ Description		:
 		<cfscript>
 			var udfOut 	= createObject("java","java.lang.StringBuilder").init('');
 			var genPath = expandPath( instance.mockBox.getGenerationPath() );
-			var tmpFile = createUUID() & ".cfc";
-			var cfcPath = replace( instance.mockBox.getGenerationPath(), "/", ".", "all" ) & listFirst( tmpFile, "." );
+			var tmpFile = "";
+			var cfcPath = "";
 			var oStub	= "";
 			var local 	= {};
+			var stubCode = "";
 
 			// Create CFC Signature
 			udfOut.append('<cfcomponent output="false" hint="A MockBox awesome Component"');
@@ -237,10 +243,15 @@ Description		:
 			udfOut.append('</cfcomponent>');
 
 			// Write it out
-			writeStub( genPath & tmpFile, udfOUt.toString() );
+			stubCode = udfOUt.toString();
+			tmpFile = hash(stubCode) & ".cfc";
+			if( !FileExists(genPath & tmpFile) ) {
+				writeStub(genPath & tmpFile, stubCode);
+			}
 
 			try{
 				// create stub + clean first . if found.
+				cfcPath = replace( instance.mockBox.getGenerationPath(), "/", ".", "all" ) & listFirst( tmpFile, "." );
 				cfcPath = reReplace( cfcPath, "^\.", "" );
 				oStub = createObject( "component", cfcPath );
 				// Remove Stub


### PR DESCRIPTION
Each time a method is mocked using $(), the code for the stub is written to disk using a unique name then included into the object and the file removed.

To improve performance, I've changed the filename generation to an MD5 hash of the code, and disabled removing the files. This allows TestBox to leverage ColdFusion template caching. This reduces the time that $() takes from ~30 ms to ~0 ms.

This is most noticeable in the TestBox test MockBoxTest.cfc, which for me was taking about 1300 ms before and 25 ms after.