### PR TITLE
Add fix for labels attached to specs with no suite label.

### DIFF
--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -562,7 +562,7 @@ component{
 			// init spec tests
 			var specStats = arguments.testResults.startSpecStats( arguments.spec.name, arguments.suiteStats );
 			// init consolidated spec labels
-			var consolidatedLabels = [];
+			var consolidatedLabels = arguments.spec.labels;
 			// Build labels from nested suites, so suites inherit from parent suite labels
 			var parentSuite = arguments.suite;
 			while( !isSimpleValue( parentSuite ) ){

--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -662,17 +662,17 @@ component{
 		if( treeLen gt 0 ){
 			for( var x=treeLen; x gte 1; x-- ){
 				var thisContext = reverseTree[ x ];
-				thisContext.beforeEach( 
-					currentSpec = arguments.spec.name, 
+				thisContext.beforeEach(
+					currentSpec = arguments.spec.name,
 					data   		= thisContext.beforeEachData
 				);
 			}
 		}
 
 		// execute beforeEach()
-		arguments.suite.beforeEach( 
-			currentSpec = arguments.spec.name, 
-			data 		= arguments.suite.beforeEachData 
+		arguments.suite.beforeEach(
+			currentSpec = arguments.spec.name,
+			data 		= arguments.suite.beforeEachData
 		);
 
 		return this;
@@ -802,7 +802,7 @@ component{
 	*/
 	BaseSpec function runAfterEachClosures( required suite, required spec ){
 		// execute nearest afterEach()
-		arguments.suite.afterEach( 
+		arguments.suite.afterEach(
 			currentSpec = arguments.spec.name,
 			data 		= arguments.suite.afterEachData
 		);
@@ -810,7 +810,7 @@ component{
 		// do we have nested suites? If so, traverse and execute life-cycle methods up the tree backwards
 		var parentSuite = arguments.suite.parentRef;
 		while( !isSimpleValue( parentSuite ) ){
-			parentSuite.afterEach( 
+			parentSuite.afterEach(
 				currentSpec = arguments.spec.name,
 				data 		= parentSuite.afterEachData
 			);
@@ -949,9 +949,9 @@ component{
 		numeric top="999"
 	){
 		// null check
-		if( isNull( arguments.var ) ){ 
-			arrayAppend( this.$debugBuffer, "null" ); 
-			return; 
+		if( isNull( arguments.var ) ){
+			arrayAppend( this.$debugBuffer, "null" );
+			return;
 		}
 
 		// lock and add
@@ -959,8 +959,8 @@ component{
 			// duplication control
 			var newVar = ( arguments.deepCopy ? duplicate( arguments.var ) : arguments.var );
 			// compute label?
-			if( !len( trim( arguments.label ) ) ){ 
-				arguments.label = this.$currentExecutingSpec; 
+			if( !len( trim( arguments.label ) ) ){
+				arguments.label = this.$currentExecutingSpec;
 			}
 			// add to debug output
 			arrayAppend( this.$debugBuffer, {
@@ -1192,7 +1192,7 @@ component{
 				arrayAppend( result, arguments.tagContext[ ix++ ] );
 			}
 		}
-		
+
 		return result;
 	}
 

--- a/system/runners/BDDRunner.cfc
+++ b/system/runners/BDDRunner.cfc
@@ -167,7 +167,6 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 
 		// Verify we can execute the incoming suite via skipping or labels
 		if( !arguments.suite.skip &&
-			canRunLabel( consolidatedLabels, arguments.testResults ) &&
 			canRunSuite( arguments.suite, arguments.testResults )
 		){
 

--- a/system/runners/UnitRunner.cfc
+++ b/system/runners/UnitRunner.cfc
@@ -153,7 +153,6 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 
 		// Verify we can execute the incoming suite via skipping or labels
 		if( !arguments.suite.skip &&
-			canRunLabel( arguments.suite.labels, arguments.testResults ) &&
 			canRunSuite( arguments.suite, arguments.testResults )
 		){
 

--- a/tests/specs/LabelsTest.cfc
+++ b/tests/specs/LabelsTest.cfc
@@ -2,15 +2,22 @@
 * My BDD Test
 */
 component extends="testbox.system.BaseSpec"{
-	
+
 /*********************************** LIFE CYCLE Methods ***********************************/
 
 	// executes before all suites+specs in the run() method
 	function beforeAll(){
+		variables.testsRan = 0;
 	}
 
 	// executes after all suites+specs in the run() method
 	function afterAll(){
+		if ( listContains( url.labels, "luis" ) ) {
+			expect( testsRan ).toBe( 4 );
+		}
+		else {
+			expect( testsRan ).toBe( 7 );
+		}
 	}
 
 /*********************************** BDD SUITES ***********************************/
@@ -18,26 +25,35 @@ component extends="testbox.system.BaseSpec"{
 	function run(){
 		describe( title="Suite with a label", labels="luis", body=function(){
 			it( "should execute", function(){
-			
+				testsRan++;
 			});
 			it( "should execute as well", function(){
-			
+				testsRan++;
 			});
 			describe( "Nested Suite", function(){
 				it( "should execute as well, as nested suite is inside a label suite", function(){
-			
+					testsRan++;
 				});
 			});
 		});
 
 		describe( "Suites with no labels", function(){
 			it( "should not execute", function(){
-			
+				testsRan++
 			});
 			it( "should not execute", function(){
-			
-			});		
+				testsRan++
+			});
 		});
+
+		describe( "Suite without a label but containing a spec with a label", function() {
+			it( title="spec with a label", labels="luis", body=function() {
+				testsRan++;
+			} );
+			it( "should not execute", function() {
+				testsRan++
+			} );
+		} );
 	}
-	
+
 }

--- a/tests/specs/LabelsTest.cfc
+++ b/tests/specs/LabelsTest.cfc
@@ -13,10 +13,10 @@ component extends="testbox.system.BaseSpec"{
 	// executes after all suites+specs in the run() method
 	function afterAll(){
 		if ( listContains( url.labels, "luis" ) ) {
-			expect( testsRan ).toBe( 4 );
+			expect( testsRan ).toBe( 5 );
 		}
 		else {
-			expect( testsRan ).toBe( 7 );
+			expect( testsRan ).toBe( 8 );
 		}
 	}
 
@@ -34,6 +34,12 @@ component extends="testbox.system.BaseSpec"{
 				it( "should execute as well, as nested suite is inside a label suite", function(){
 					testsRan++;
 				});
+
+				describe( "Double Nested Suite", function() {
+					it( "should execute this spec as well, because a parent suite has the correct label", function() {
+					    testsRan++;
+					} );
+				} );
 			});
 		});
 

--- a/tests/specs/LabelsTest.cfc
+++ b/tests/specs/LabelsTest.cfc
@@ -45,10 +45,10 @@ component extends="testbox.system.BaseSpec"{
 
 		describe( "Suites with no labels", function(){
 			it( "should not execute", function(){
-				testsRan++
+				testsRan++;
 			});
 			it( "should not execute", function(){
-				testsRan++
+				testsRan++;
 			});
 		});
 
@@ -57,7 +57,7 @@ component extends="testbox.system.BaseSpec"{
 				testsRan++;
 			} );
 			it( "should not execute", function() {
-				testsRan++
+				testsRan++;
 			} );
 		} );
 	}


### PR DESCRIPTION
Given the following spec:
```
component extends="coldbox.system.testing.BaseTestCase" appMapping="/root"{

    function run() {
        describe( "Main Handler" function() {
            beforeEach( function() {
                setup();
            } );

            it( title = "+homepage renders", labels = "dev", body = function() {
                var event = execute( event = "main.index", renderResults = true );
                expect( event.getValue( name = "welcomemessage", private = true ) ).toBe( "Welcome to ColdBox!" );
            } );

            it( "+doSomething relocates", function() {
                var event = execute( event="main.doSomething" );
                expect( event.getValue( "setnextevent_event", "" ) ).toBe( "main.index" );
            } );
        } );
    }

}
```

When running with no labels, I expect to run two specs.  When running with `?labels=dev` in the url, I expect to run one spec.  However, I current get no specs ran.  TestBox doesn't even try to look for specs to run if the suite doesn't have the label.  This pull request fixes that behavior so TestBox will run specs with the correct label even when the suite itself does not have that label.