### PR TITLE
notKey validation message

### DIFF
--- a/system/Assertion.cfc
+++ b/system/Assertion.cfc
@@ -264,7 +264,7 @@ component{
 	* @message.hint The message to send in the failure
 	*/
 	function notKey( required any target, required string key, message=""){
-		arguments.message = ( len( arguments.message ) ? arguments.message : "The key [#arguments.key#] exists in the target object. Found keys are [#structKeyArray( arguments.target ).toString()#]" );
+		arguments.message = ( len( arguments.message ) ? arguments.message : "The key [#arguments.key#] does not exist in the target object. Found keys are [#structKeyArray( arguments.target ).toString()#]" );
 		if( !structKeyExists( arguments.target, arguments.key ) ){ return this; }
 		fail( arguments.message );
 	}


### PR DESCRIPTION
notKey validation message should say the key was not found.

As mentioned in the testing CFML slack room