### PR TITLE
exclude "empty" test suites from antjunit report

### DIFF
--- a/system/reports/ANTJUnitReporter.cfc
+++ b/system/reports/ANTJUnitReporter.cfc
@@ -43,7 +43,10 @@ component{
 		// iterate over bundles
 		var bundlestats = r.getBundleStats();
 		for( var thisBundle in bundleStats ){
-
+			// excluding "empty" test suites
+			if (structKeyExists(url, 'testBundles') AND len( url.testBundles ) and !listFindNoCase( url.testBundles, thisBundle.path )){
+				continue;
+			}
 			// build test suite header
 			buffer.append('<testsuite
 			tests="#thisBundle.totalSpecs#"


### PR DESCRIPTION
Possible patch to exclude "empty" test suites from antjunit report. Similar to how it's done in simple report.