### PR TITLE
Fixed issue with invalid XML report result.

### DIFF
--- a/system/reports/ANTJUnitReporter.cfc
+++ b/system/reports/ANTJUnitReporter.cfc
@@ -117,7 +117,7 @@ component{
 
 		switch( stats.status ){
 			case "failed" : {
-				out.append('<failure message="#xmlformat( stats.failMessage )#"><![CDATA[
+				out.append('<failure message="#xmlformat( stats.failMessage, true )#"><![CDATA[
 					#stats.failorigin.toString()#
 					]]></failure>');
 				break;
@@ -127,7 +127,7 @@ component{
 				break;
 			}
 			case "error" : {
-				out.append('<error type="#xmlFormat( stats.error.type )#" message="#xmlformat( stats.error.message )#"><![CDATA[
+				out.append('<error type="#xmlFormat( stats.error.type )#" message="#xmlformat( stats.error.message, true )#"><![CDATA[
 					#stats.error.stackTrace.toString()#
 					]]></error>');
 				break;

--- a/system/reports/JUnitReporter.cfc
+++ b/system/reports/JUnitReporter.cfc
@@ -121,7 +121,7 @@ component{
 
 		switch( stats.status ){
 			case "failed" : {
-				out.append('<failure message="#xmlformat( stats.failMessage )#"><![CDATA[
+				out.append('<failure message="#xmlformat( stats.failMessage, true )#"><![CDATA[
 					#stats.failorigin.toString()#
 					]]></failure>');
 				break;
@@ -131,7 +131,7 @@ component{
 				break;
 			}
 			case "error" : {
-				out.append('<error type="#xmlFormat( stats.error.type )#" message="#xmlformat( stats.error.message )#"><![CDATA[
+				out.append('<error type="#xmlFormat( stats.error.type )#" message="#xmlformat( stats.error.message, true )#"><![CDATA[
 					#stats.error.stackTrace.toString()#
 					]]></error>');
 				break;


### PR DESCRIPTION
Fixed issue with invalid XML result. Needed to escape to prevent errors. Found when assertEquals() fail message contained a string with a special character (eg. chr(2)) then isXML() is false and an xmlParse() attempt throws exception.