### PR TITLE
Don't re-mock already mocked objects.

### DIFF
--- a/system/MockBox.cfc
+++ b/system/MockBox.cfc
@@ -114,6 +114,9 @@ Description		:
 		<cfargument name="callLogging" 	type="boolean" 	required="false" default="true" hint="Add method call logging for all mocked methods"/>
 		<!--- ************************************************************* --->
 		<cfscript>
+			if ( structKeyExists( arguments.object, "mockbox" ) ) {
+				return arguments.object;
+			}
 			return createMock(object=arguments.object);
 		</cfscript>
 	</cffunction>


### PR DESCRIPTION
Right now every time you call `prepareMock` on an object, the previous mock expectations are lost.  The PR changes that to only mocking non-mocked objects.