### PR TITLE
Fix for new version of Lucee

### DIFF
--- a/system/mockutils/MockGenerator.cfc
+++ b/system/mockutils/MockGenerator.cfc
@@ -330,7 +330,7 @@ Description		:
 				// iterate over the values of the function
 				for( local.fncKey in local.oMD[ x ] ){
 					// Do Simple values only
-					if( NOT local.fncKey eq "parameters" ){
+					if( isSimpleValue(local.oMD[ x ][ local.fncKey ]) ){
 						udfOut.append(' #lcase( local.fncKey )#="#local.oMD[ x ][ local.fncKey ]#"');
 					}
 				}


### PR DESCRIPTION
There is a new key "position" added to the struct which is not a simple value.

![image](https://user-images.githubusercontent.com/6120946/36990935-c49ba17e-206b-11e8-8d29-108ba5b4e4df.png)
