### PR TITLE
add sort criteria to test browser file and folder list

### DIFF
--- a/test-browser/index.cfm
+++ b/test-browser/index.cfm
@@ -32,7 +32,7 @@
 </cfif>
 
 <!--- Get list of files --->
-<cfdirectory action="list" directory="#rootPath & url.path#" name="qResults" sort="asc" >
+<cfdirectory action="list" directory="#rootPath & url.path#" name="qResults" sort="directory asc, name asc">
 <!--- Get the execute path --->
 <cfset executePath = rootMapping & ( url.path eq "/" ? "/" : url.path & "/" )>
 <!--- Get the Back Path --->


### PR DESCRIPTION
Here's an update to the TestBox test browser page for your consideration. I noticed the file/folder list displayed on the test browser page was not sorting properly so I added sort criteria to the directory listing to sort by directory then name. 