### PR TITLE
Update SimpleReporter.cfc

### DIFF
--- a/system/reports/SimpleReporter.cfc
+++ b/system/reports/SimpleReporter.cfc
@@ -14,7 +14,7 @@ component{
 	* Get the name of the reporter
 	*/
 	function getName(){
-		return "Simple";
+		return "SimpleReporter";
 	}
 
 	/**


### PR DESCRIPTION
Clicking on an individual Spec caused an error. Testbox was looking for a different getName value. Updated the reporter to supply the correct value.