### PR TITLE
arguments for notMatchWithCase inconsistent with other matchers

### DIFF
--- a/system/Assertion.cfc
+++ b/system/Assertion.cfc
@@ -246,6 +246,18 @@ component{
 	}
 
 	/**
+	* Assert that the actual data does NOT match the incoming regular expression with case sensitivity
+	* @actual The actual data to check
+	* @regex The regex to check with
+	* @message The message to send in the failure
+	*/
+	function notMatchWithCase( required string actual, required string regex, message=""){
+		arguments.message = ( len( arguments.message ) ? arguments.message : "The actual [#arguments.actual.toString()#] actually matches [#arguments.regex#]" );
+		if( arrayLen( reMatch( arguments.regex, arguments.actual ) ) eq 0 ){ return this; }
+		fail( arguments.message );
+	}
+
+	/**
 	* Assert that a given key exists in the passed in struct/object
 	* @target The target object/struct
 	* @key The key to check for existence

--- a/system/Expectation.cfc
+++ b/system/Expectation.cfc
@@ -226,14 +226,13 @@ component accessors="true"{
 
 	/**
 	* Assert that the actual data matches the incoming regular expression with case sensitivity
-	* @actual The actual data to check
 	* @regex The regex to check with
 	* @message The message to send in the failure
 	*/
-	function toMatchWithCase( required string actual, required string regex, message=""){
+	function toMatchWithCase( required string regex, message=""){
 		arguments.actual = this.actual;
 		if( this.isNot ){
-			variables.assert.notMatch( argumentCollection=arguments );
+			variables.assert.notMatchWithCase( argumentCollection=arguments );
 		} else {
 			variables.assert.matchWithCase( argumentCollection=arguments );
 		}

--- a/tests/specs/Assertionscf9Test.cfc
+++ b/tests/specs/Assertionscf9Test.cfc
@@ -223,11 +223,15 @@ component displayName="TestBox xUnit suite for CF9" labels="lucee,cf" extends="t
 	}
 
 	function testMatchWithCase(){
-		$assert.match( "This testing is my test", "(test)$" );
+		$assert.matchWithCase( "This testing is my TEST", "(TEST)$" );
 	}
 
 	function testNotMatch(){
 		$assert.notMatch( "This testing is my test", "(hello)$" );
+	}
+
+	function testNotMatchWithCase(){
+		$assert.notMatchWithCase( "This testing is my TEST", "(test)$" );
 	}
 
 	function testKey(){

--- a/tests/specs/BDDTest.cfc
+++ b/tests/specs/BDDTest.cfc
@@ -60,6 +60,16 @@ component extends="testbox.system.BaseSpec"{
 				expect(	0 ).notToSatisfy( function( num ){ return arguments.num > 0; } );
 			});
 
+			it( "can match using regular expressions with no case sensitivity", function(){
+				expect(	"Matches End" ).toMatch( "end$" );
+				expect(	"Matches End" ).notToMatch( "^end" );
+			});
+
+			it( "can match using regular expressions and case sensitivity", function(){
+				expect(	"Matches End" ).toMatchWithCase( "End$" );
+				expect(	"Matches End" ).notToMatchWithCase( "^End" );
+			});
+
 			it( "can validate json", function(){
 				var data = serializeJSON( { name = "luis", when = now() } );
 				expect( "luis" ).notToBeJSON();


### PR DESCRIPTION
Noticed that `toMatchWithCase` had a signature of:

```
toMatchWithCase( required string actual, required string regex, message="")
```

Looking at toMatch the 'actual' argument should not be passed in.