### PR TITLE
bddrunner.cfm: now compiles properly on ACF

### DIFF
--- a/tests/runners/bddrunner.cfm
+++ b/tests/runners/bddrunner.cfm
@@ -1,11 +1,13 @@
 <cfsetting showdebugoutput="false" >
 <cfparam name="url.reporter" default="simple"> 
-<!--- One runner --->
-<cfset r = new testbox.system.TestBox( "testbox.tests.specs.BDDTest" ) >
-<cfoutput>#r.run( reporter="#url.reporter#", callbacks={
+<cfscript>
+  /* One Runner */
+  r = new testbox.system.TestBox( "testbox.tests.specs.BDDTest" );
+
+  writeOutput( r.run( reporter="#url.reporter#", callbacks={
 	onBundleStart 	= function( bundle, testResults ){
-		writeDump( var="onBundleStart", output="console" );
-	},
+                writeDump( var="onBundleStart", output="console" );
+        },
 	onBundleEnd 	= function( bundle, testResults ){
 		writeDump( var="onBundleEnd", output="console" );
 	},
@@ -21,4 +23,5 @@
 	onSpecEnd 		= function( bundle, testResults, suite, spec ){
 		writeDump( var="onSpecEnd", output="console" );
 	}
-} )#</cfoutput>
+} ) );
+</cfscript>


### PR DESCRIPTION
Did not compile properly on ACF11 + ACF2016, due to anonymous functions within pound signs... I attempted to move the anon functions into cfset, but they didn't work there either.

I moved the bulk of it to cfscript and Adobe is happy now.  The other two tags could probably be converted but my script experience is lacking.

Alternatively, maybe this runner isn't even needed anymore?  Address as you will.
