### PR TITLE
remove depricated function htmlEditFormat

### DIFF
--- a/system/coverage/browser/formatter.cfc
+++ b/system/coverage/browser/formatter.cfc
@@ -140,7 +140,7 @@
 				<a href='javascript:show_about_#arguments.codesig#()' style='#getStyle("TOOLBARLINK")#'>about</a>
 				<span id='about_#arguments.codesig#' style=';display:none;font-style:italic;'><a href='http://coldfish.riaforge.org/' style='#getStyle("TOOLBARLINK")#;margin:0 0 0 0;' target='_blank'>ColdFISH</a> is developed by <a href='http://www.cfinsider.com/' style='#getStyle("TOOLBARLINK")#;margin:0 0 0 0;' target='_blank'>Jason Delmore</a>.  Source code and license information available at <a href='http://coldfish.riaforge.org/' style='#getStyle("TOOLBARLINK")#;margin:0 0 0 0;' target='_blank'>coldfish.riaforge.org</a>.  Version 3.1.1</span>
 			</div>	
-			<pre id='htmlencoded_plain_#arguments.codesig#' style='display:none;#getStyle("TEXT")#;margin:0 0 0 0;'>#htmleditformat(arguments.code)#</pre>
+			<pre id='htmlencoded_plain_#arguments.codesig#' style='display:none;#getStyle("TEXT")#;margin:0 0 0 0;'>#encodeForHTML(arguments.code)#</pre>
 		")/>
 	</cffunction>
 	

--- a/system/reports/assets/codexwiki.cfm
+++ b/system/reports/assets/codexwiki.cfm
@@ -56,12 +56,12 @@
 <p>#local.thisSpec.name# (#local.thisSpec.totalDuration# ms)</p>
 	
 <cfif local.thisSpec.status eq "failed">
-* '''#htmlEditFormat( local.thisSpec.failMessage )#'''
+* '''#encodeForHTML( local.thisSpec.failMessage )#'''
 <pre>#local.thisSpec.failOrigin.toString()#</pre>
 </cfif>
 
 <cfif local.thisSpec.status eq "error">
-* '''#htmlEditFormat( local.thisSpec.error.message )#'''
+* '''#encodeForHTML( local.thisSpec.error.message )#'''
 <pre>#local.thisSpec.error.stacktrace#</pre>
 </cfif>
 </cfloop>

--- a/system/reports/assets/doc.cfm
+++ b/system/reports/assets/doc.cfm
@@ -68,12 +68,12 @@
 				</dt>
 					
 				<cfif local.thisSpec.status eq "failed">
-					<dd>#htmlEditFormat( local.thisSpec.failMessage )#</dd>
+					<dd>#encodeForHTML( local.thisSpec.failMessage )#</dd>
 					<dd><textarea cols="100" rows="20">#local.thisSpec.failOrigin.toString()#</textarea></dd>
 				</cfif>
 				
 				<cfif local.thisSpec.status eq "error">
-					<dd>#htmlEditFormat( local.thisSpec.error.message )#</dd>
+					<dd>#encodeForHTML( local.thisSpec.error.message )#</dd>
 					<dd><textarea cols="100" rows="20">#local.thisSpec.error.stacktrace#</textarea></dd>
 				</cfif>
 			</cfloop>

--- a/system/reports/assets/dot.cfm
+++ b/system/reports/assets/dot.cfm
@@ -114,8 +114,8 @@
 			<!--- Iterate over suite specs --->
 			<cfloop array="#arguments.suiteStats.specStats#" index="thisSpec">
 				<a href="javascript:showInfo( '#JSStringFormat( thisSpec.failMessage )#', '#thisSpec.id#', '#lcase( NOT structIsEmpty( thisSpec.error ) )#' )"
-				   title="#htmlEditFormat( thisSpec.name )# (#thisSpec.totalDuration# ms)"
-				   data-info="#HTMLEditFormat( thisSpec.failMessage )#"><span class="#lcase( thisSpec.status )#">.</span></a>
+				   title="#encodeForHTML( thisSpec.name )# (#thisSpec.totalDuration# ms)"
+				   data-info="#encodeForHTML( thisSpec.failMessage )#"><span class="#lcase( thisSpec.status )#">.</span></a>
 
 				<div style="display:none;" id="error_#thisSpec.id#"><cfdump var="#thisSpec.error#"></div>
 			</cfloop>

--- a/system/reports/assets/simple.cfm
+++ b/system/reports/assets/simple.cfm
@@ -194,7 +194,7 @@
 						<a href="#variables.baseURL#&testSpecs=#URLEncodedFormat( local.thisSpec.name )#&testBundles=#URLEncodedFormat( arguments.bundleStats.path )#" class="#lcase( local.thisSpec.status )#">#local.thisSpec.name# (#local.thisSpec.totalDuration# ms)</a>
 
 						<cfif local.thisSpec.status eq "failed">
-							- <strong class="preserve-whitespace">#htmlEditFormat( local.thisSpec.failMessage )#</strong>
+							- <strong class="preserve-whitespace">#encodeForHTML( local.thisSpec.failMessage )#</strong>
 							  <button onclick="toggleDebug( '#local.thisSpec.id#' )" title="Show more information">+</button><br>
 							  
 							  <cfif arrayLen( local.thisSpec.failOrigin )>
@@ -210,7 +210,7 @@
 						</cfif>
 
 						<cfif local.thisSpec.status eq "error">
-							- <strong>#htmlEditFormat( local.thisSpec.error.message )#</strong>
+							- <strong>#encodeForHTML( local.thisSpec.error.message )#</strong>
 							  <button onclick="toggleDebug( '#local.thisSpec.id#' )" title="Show more information">+</button><br>
 							  
 							  <cfif arrayLen( local.thisSpec.failOrigin )>


### PR DESCRIPTION
depricated since cf2016, unsupported since cf2018
https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-functions/functions-h-im/htmleditformat.html