### PR TITLE
 Reorganize panels

### DIFF
--- a/system/coverage/CoverageService.cfc
+++ b/system/coverage/CoverageService.cfc
@@ -116,7 +116,7 @@ component accessors="true" {
 	/**
 	* Render HTML representation of statistics
 	*/
-	function renderStats( required struct coverageData ) {
+	function renderStats( required struct coverageData, boolean fullPage=true ) {
 		var stats = coverageData.stats;
 		var pathToCapture = getCoverageOptions().pathToCapture;
 

--- a/system/coverage/stats/coverageStats.cfm
+++ b/system/coverage/stats/coverageStats.cfm
@@ -1,88 +1,140 @@
 <!---
 	Template for outputting overview stats about the line coverage details that were captured.
  --->
+<cfset ASSETS_DIR=expandPath( "/testbox/system/reports/assets" )>
 <cfoutput>
-	<cfif isDefined( 'stats' )>
-		<cfset totalProjectCoverage = round( stats.percTotalCoverage*100 )>
-		<div class="list-group mb-3">
-			<div class="list-group-item list-group-item-info" id="coverageStats">
-				<h2 class="clearfix">
-					<span>Code Coverage Stats</span>
-					<div class="mt-2 h5 float-right">
-						<button class="btn btn-link float-right py-0 expand-collapse collapsed" id="btn_coverageStats" onclick="toggleDebug( 'coverageStats' )" title="Show coverage stats">
-							<i class="arrow" aria-hidden="true"></i>
-						</button>
-						<span class="ml-2">Total Files Processed:<span class="badge badge-info ml-1">#stats.numFiles#</span></span>
-						<span>
-							<span class="h5 float-left">Total project coverage:</span>
-							<div class="float-left" style="width:200px;">
-								<div class="ml-1 progress position-relative" style="height: 1.4rem;">
-									<div class="progress-bar bg-#codeBrowser.percentToContextualClass(totalProjectCoverage)#" role="progressbar" style="width: #totalProjectCoverage#%" aria-valuenow="#totalProjectCoverage#" aria-valuemin="0" aria-valuemax="100">
-									</div>
-									<div class="progress-bar bg-secondary" role="progressbar" style="width: #100 - totalProjectCoverage#%" aria-valuenow="#100 - totalProjectCoverage#" aria-valuemin="0" aria-valuemax="100">
-									</div>
-									<span class="justify-content-center text-light d-flex position-absolute w-100" style="line-height: 1.25rem; font-size: 1.2rem;">
-										#totalProjectCoverage#% coverage
-									</span>
+<cfif fullPage>
+	<!DOCTYPE html>
+	<html>
+		<head>
+			<meta charset="utf-8">
+			<meta name="generator" content="TestBox v#testbox.getVersion()#">
+			<title>Pass: #results.getTotalPass()# Fail: #results.getTotalFail()# Errors: #results.getTotalError()#</title>
+
+			<style>#fileRead( '#ASSETS_DIR#/css/bootstrap.min.css' )#</style>
+			<script>#fileRead( '#ASSETS_DIR#/js/jquery-3.3.1.min.js' )#</script>
+			<script>#fileRead( '#ASSETS_DIR#/js/popper.min.js' )#</script>
+			<script>#fileRead( '#ASSETS_DIR#/js/bootstrap.min.js' )#</script>
+			<script>#fileRead( '#ASSETS_DIR#/js/stupidtable.min.js' )#</script>
+
+			<style>
+			[data-toggle="collapse"] .arrow:before,
+			.expand-collapse .arrow:before {
+				content: "\2b06";
+			}
+
+			[data-toggle="collapse"].collapsed .arrow:before,
+			.expand-collapse.collapsed .arrow:before {
+				content: "\2b07";
+			}
+
+			code {
+				color: black !important;
+			}
+			</style>
+		</head>
+		<body>
+</cfif>
+<cfif isDefined( 'stats' )>
+	<cfset totalProjectCoverage = round( stats.percTotalCoverage*100 )>
+	<div class="list-group mb-3">
+		<div class="list-group-item list-group-item-info" id="coverageStats">
+			<h2 class="clearfix">
+				<span>Code Coverage Stats</span>
+				<div class="mt-2 h5 float-right">
+					<button class="btn btn-link float-right py-0 expand-collapse collapsed" id="btn_coverageStats" onclick="toggleDebug( 'coverageStats' )" title="Show coverage stats">
+						<span class="arrow" aria-hidden="true"></span>
+					</button>
+					<span class="ml-2">Total Files Processed:<span class="badge badge-info ml-1">#stats.numFiles#</span></span>
+					<span>
+						<span class="h5 float-left">Total project coverage:</span>
+						<div class="float-left" style="width:200px;">
+							<div class="ml-1 progress position-relative" style="height: 1.4rem;">
+								<div class="progress-bar bg-#codeBrowser.percentToContextualClass(totalProjectCoverage)#" role="progressbar" style="width: #totalProjectCoverage#%" aria-valuenow="#totalProjectCoverage#" aria-valuemin="0" aria-valuemax="100">
 								</div>
+								<div class="progress-bar bg-secondary" role="progressbar" style="width: #100 - totalProjectCoverage#%" aria-valuenow="#100 - totalProjectCoverage#" aria-valuemin="0" aria-valuemax="100">
+								</div>
+								<span class="justify-content-center text-light d-flex position-absolute w-100" style="line-height: 1.25rem; font-size: 1.2rem;">
+									#totalProjectCoverage#% coverage
+								</span>
 							</div>
-						</span>
-					</div>
-				</h2>
-
-				<cfif len( coverageData.sonarQubeResults ) >
-					<h6 class="mt-2">
-						SonarQube code coverage XML file generated in #coverageData.sonarQubeResults#
-					</h6>
-				</cfif>
-
-				<cfif len( coverageData.browserResults ) >
-					<h6 class="mt-2">
-						Coverage Browser generated in #coverageData.browserResults#
-					</h6>
-				</cfif>
-				<div class="my-3 debugdata" style="display:none;" data-specid="coverageStats">
-					<ul class="list-group">
-						<li class="list-group-item">
-							<h4>Files with best coverage:</h4>
-							<ol class="list-group">
-								<cfloop query="stats.qryFilesBestCoverage">
-									<cfset percentage = round( percCoverage*100 )>
-									<cfset trimmedFilePath = replaceNoCase( filePath, pathToCapture, '' )>
-									<li class="list-group-item list-group-item-#codeBrowser.percentToContextualClass( percentage )#">
-										<span class="col-9">#trimmedFilePath#</span>
-										<div class=" col-3 d-inline-flex float-right">
-											<div class="progress position-relative w-100">
-												<div class="progress-bar bg-#codeBrowser.percentToContextualClass( percentage )#" role="progressbar" style="width: #percentage#%" aria-valuenow="#percentage#" aria-valuemin="0" aria-valuemax="100"></div>
-												<div class="progress-bar bg-secondary" role="progressbar" style="width: #100-percentage#%" aria-valuenow="#100-percentage#" aria-valuemin="0" aria-valuemax="100"></div>
-												<span class="justify-content-center text-light d-flex position-absolute w-100">#percentage#% coverage</span>
-											</div>
-										</div>
-									</li>
-								</cfloop>
-							</ol>
-						</li>
-						<li class="list-group-item">
-							<h4>Files with worst coverage:</h4>
-							<ol class="list-group">
-								<cfloop query="stats.qryFilesWorstCoverage">
-									<cfset percentage = round( percCoverage*100 )>
-									<li class="list-group-item list-group-item-#codeBrowser.percentToContextualClass( percentage )#">
-										<span class="col-9">#trimmedFilePath#</span>
-										<div class=" col-3 d-inline-flex float-right">
-											<div class="progress position-relative w-100">
-												<div class="progress-bar bg-#codeBrowser.percentToContextualClass( percentage )#" role="progressbar" style="width: #percentage#%" aria-valuenow="#percentage#" aria-valuemin="0" aria-valuemax="100"></div>
-												<div class="progress-bar bg-secondary" role="progressbar" style="width: #100-percentage#%" aria-valuenow="#100-percentage#" aria-valuemin="0" aria-valuemax="100"></div>
-												<span class="justify-content-center text-light d-flex position-absolute w-100">#percentage#% coverage</span>
-											</div>
-										</div>
-									</li>
-								</cfloop>
-							</ol>
-						</li>
-					</ul>
+						</div>
+					</span>
 				</div>
+			</h2>
+
+			<cfif len( coverageData.sonarQubeResults ) >
+				<h6 class="mt-2">
+					SonarQube code coverage XML file generated in #coverageData.sonarQubeResults#
+				</h6>
+			</cfif>
+
+			<cfif len( coverageData.browserResults ) >
+				<h6 class="mt-2">
+					Coverage Browser generated in #coverageData.browserResults#
+				</h6>
+			</cfif>
+			<div class="my-3 debugdata" <cfif !fullPage>style="display:none;" </cfif>data-specid="coverageStats">
+				<ul class="list-group">
+					<li class="list-group-item">
+						<h4>Files with best coverage:</h4>
+						<ol class="list-group">
+							<cfloop query="stats.qryFilesBestCoverage">
+								<cfset percentage = round( percCoverage*100 )>
+								<cfset trimmedFilePath = replaceNoCase( filePath, pathToCapture, '' )>
+								<li class="list-group-item list-group-item-#codeBrowser.percentToContextualClass( percentage )#">
+									<span class="col-9">#trimmedFilePath#</span>
+									<div class=" col-3 d-inline-flex float-right">
+										<div class="progress position-relative w-100">
+											<div class="progress-bar bg-#codeBrowser.percentToContextualClass( percentage )#" role="progressbar" style="width: #percentage#%" aria-valuenow="#percentage#" aria-valuemin="0" aria-valuemax="100"></div>
+											<div class="progress-bar bg-secondary" role="progressbar" style="width: #100-percentage#%" aria-valuenow="#100-percentage#" aria-valuemin="0" aria-valuemax="100"></div>
+											<span class="justify-content-center text-light d-flex position-absolute w-100">#percentage#% coverage</span>
+										</div>
+									</div>
+								</li>
+							</cfloop>
+						</ol>
+					</li>
+					<li class="list-group-item">
+						<h4>Files with worst coverage:</h4>
+						<ol class="list-group">
+							<cfloop query="stats.qryFilesWorstCoverage">
+								<cfset percentage = round( percCoverage*100 )>
+								<li class="list-group-item list-group-item-#codeBrowser.percentToContextualClass( percentage )#">
+									<span class="col-9">#trimmedFilePath#</span>
+									<div class=" col-3 d-inline-flex float-right">
+										<div class="progress position-relative w-100">
+											<div class="progress-bar bg-#codeBrowser.percentToContextualClass( percentage )#" role="progressbar" style="width: #percentage#%" aria-valuenow="#percentage#" aria-valuemin="0" aria-valuemax="100"></div>
+											<div class="progress-bar bg-secondary" role="progressbar" style="width: #100-percentage#%" aria-valuenow="#100-percentage#" aria-valuemin="0" aria-valuemax="100"></div>
+											<span class="justify-content-center text-light d-flex position-absolute w-100">#percentage#% coverage</span>
+										</div>
+									</div>
+								</li>
+							</cfloop>
+						</ol>
+					</li>
+				</ul>
 			</div>
 		</div>
-	</cfif>
+	</div>
+</cfif>
 </cfoutput>
+<cfif fullPage>
+		<script>
+			function toggleDebug(specid) {
+				$(`#btn_${specid}`).toggleClass("collapsed");
+				$("div.debugdata").each(function() {
+					var $this = $(this);
+
+					// if bundleid passed and not the same bundle
+					if (specid != undefined && $this.attr("data-specid") != specid) {
+						return;
+					}
+					// toggle.
+					$this.slideToggle();
+				});
+			}
+			</script>
+		</body>
+	</html>
+</cfif>

--- a/system/coverage/stats/coverageStats.cfm
+++ b/system/coverage/stats/coverageStats.cfm
@@ -4,86 +4,85 @@
 <cfoutput>
 	<cfif isDefined( 'stats' )>
 		<cfset totalProjectCoverage = round( stats.percTotalCoverage*100 )>
-
-		<div class="list-group-item list-group-item-info" id="coverageStats">
-			<h2 class="clearfix">
-				<span>Coverage Stats</span>
-				<div class="mt-2 h5 float-right">
-					<button class="btn btn-link float-right py-0 expand-collapse collapsed" id="btn_coverageStats" onclick="toggleDebug( 'coverageStats' )" title="Show coverage stats">
-						<i class="arrow" aria-hidden="true"></i>
-					</button>
-					<span class="ml-2">Total Files Processed:<span class="badge badge-info ml-1">#stats.numFiles#</span></span>
-					<span>
-						<span class="h5 float-left">Total project coverage:</span>
-						<div class="float-left" style="width:200px;">
-							<div class="ml-1 progress position-relative" style="height: 1.4rem;">
-								<div class="progress-bar bg-#codeBrowser.percentToContextualClass(totalProjectCoverage)#" role="progressbar" style="width: #totalProjectCoverage#%" aria-valuenow="#totalProjectCoverage#" aria-valuemin="0" aria-valuemax="100">
+		<div class="list-group mb-3">
+			<div class="list-group-item list-group-item-info" id="coverageStats">
+				<h2 class="clearfix">
+					<span>Code Coverage Stats</span>
+					<div class="mt-2 h5 float-right">
+						<button class="btn btn-link float-right py-0 expand-collapse collapsed" id="btn_coverageStats" onclick="toggleDebug( 'coverageStats' )" title="Show coverage stats">
+							<i class="arrow" aria-hidden="true"></i>
+						</button>
+						<span class="ml-2">Total Files Processed:<span class="badge badge-info ml-1">#stats.numFiles#</span></span>
+						<span>
+							<span class="h5 float-left">Total project coverage:</span>
+							<div class="float-left" style="width:200px;">
+								<div class="ml-1 progress position-relative" style="height: 1.4rem;">
+									<div class="progress-bar bg-#codeBrowser.percentToContextualClass(totalProjectCoverage)#" role="progressbar" style="width: #totalProjectCoverage#%" aria-valuenow="#totalProjectCoverage#" aria-valuemin="0" aria-valuemax="100">
+									</div>
+									<div class="progress-bar bg-secondary" role="progressbar" style="width: #100 - totalProjectCoverage#%" aria-valuenow="#100 - totalProjectCoverage#" aria-valuemin="0" aria-valuemax="100">
+									</div>
+									<span class="justify-content-center text-light d-flex position-absolute w-100" style="line-height: 1.25rem; font-size: 1.2rem;">
+										#totalProjectCoverage#% coverage
+									</span>
 								</div>
-								<div class="progress-bar bg-secondary" role="progressbar" style="width: #100 - totalProjectCoverage#%" aria-valuenow="#100 - totalProjectCoverage#" aria-valuemin="0" aria-valuemax="100">
-								</div>
-								<span class="justify-content-center text-light d-flex position-absolute w-100" style="line-height: 1.25rem; font-size: 1.2rem;">
-									#totalProjectCoverage#% coverage
-								</span>
 							</div>
-						</div>
-					</span>
+						</span>
+					</div>
+				</h2>
+
+				<cfif len( coverageData.sonarQubeResults ) >
+					<h6 class="mt-2">
+						SonarQube code coverage XML file generated in #coverageData.sonarQubeResults#
+					</h6>
+				</cfif>
+
+				<cfif len( coverageData.browserResults ) >
+					<h6 class="mt-2">
+						Coverage Browser generated in #coverageData.browserResults#
+					</h6>
+				</cfif>
+				<div class="my-3 debugdata" style="display:none;" data-specid="coverageStats">
+					<ul class="list-group">
+						<li class="list-group-item">
+							<h4>Files with best coverage:</h4>
+							<ol class="list-group">
+								<cfloop query="stats.qryFilesBestCoverage">
+									<cfset percentage = round( percCoverage*100 )>
+									<cfset trimmedFilePath = replaceNoCase( filePath, pathToCapture, '' )>
+									<li class="list-group-item list-group-item-#codeBrowser.percentToContextualClass( percentage )#">
+										<span class="col-9">#trimmedFilePath#</span>
+										<div class=" col-3 d-inline-flex float-right">
+											<div class="progress position-relative w-100">
+												<div class="progress-bar bg-#codeBrowser.percentToContextualClass( percentage )#" role="progressbar" style="width: #percentage#%" aria-valuenow="#percentage#" aria-valuemin="0" aria-valuemax="100"></div>
+												<div class="progress-bar bg-secondary" role="progressbar" style="width: #100-percentage#%" aria-valuenow="#100-percentage#" aria-valuemin="0" aria-valuemax="100"></div>
+												<span class="justify-content-center text-light d-flex position-absolute w-100">#percentage#% coverage</span>
+											</div>
+										</div>
+									</li>
+								</cfloop>
+							</ol>
+						</li>
+						<li class="list-group-item">
+							<h4>Files with worst coverage:</h4>
+							<ol class="list-group">
+								<cfloop query="stats.qryFilesWorstCoverage">
+									<cfset percentage = round( percCoverage*100 )>
+									<li class="list-group-item list-group-item-#codeBrowser.percentToContextualClass( percentage )#">
+										<span class="col-9">#trimmedFilePath#</span>
+										<div class=" col-3 d-inline-flex float-right">
+											<div class="progress position-relative w-100">
+												<div class="progress-bar bg-#codeBrowser.percentToContextualClass( percentage )#" role="progressbar" style="width: #percentage#%" aria-valuenow="#percentage#" aria-valuemin="0" aria-valuemax="100"></div>
+												<div class="progress-bar bg-secondary" role="progressbar" style="width: #100-percentage#%" aria-valuenow="#100-percentage#" aria-valuemin="0" aria-valuemax="100"></div>
+												<span class="justify-content-center text-light d-flex position-absolute w-100">#percentage#% coverage</span>
+											</div>
+										</div>
+									</li>
+								</cfloop>
+							</ol>
+						</li>
+					</ul>
 				</div>
-			</h2>
-
-			<cfif len( coverageData.sonarQubeResults ) >
-				<h6 class="mt-2">
-					SonarQube code coverage XML file generated in #coverageData.sonarQubeResults#
-				</h6>
-			</cfif>
-
-			<cfif len( coverageData.browserResults ) >
-				<h6 class="mt-2">
-					Coverage Browser generated in #coverageData.browserResults#
-				</h6>
-			</cfif>
-			<div class="my-3 debugdata" style="display:none;" data-specid="coverageStats">
-				<ul class="list-group">
-					<li class="list-group-item">
-						<h4>Files with best coverage:</h4>
-						<ol class="list-group">
-							<cfloop query="stats.qryFilesBestCoverage">
-								<cfset percentage = round( percCoverage*100 )>
-								<cfset trimmedFilePath = replaceNoCase( filePath, pathToCapture, '' )>
-								<li class="list-group-item list-group-item-#codeBrowser.percentToContextualClass( percentage )#">
-									<span class="col-9">#trimmedFilePath#</span>
-									<div class=" col-3 d-inline-flex float-right">
-										<div class="progress position-relative w-100">
-											<div class="progress-bar bg-#codeBrowser.percentToContextualClass( percentage )#" role="progressbar" style="width: #percentage#%" aria-valuenow="#percentage#" aria-valuemin="0" aria-valuemax="100"></div>
-											<div class="progress-bar bg-secondary" role="progressbar" style="width: #100-percentage#%" aria-valuenow="#100-percentage#" aria-valuemin="0" aria-valuemax="100"></div>
-											<span class="justify-content-center text-light d-flex position-absolute w-100">#percentage#% coverage</span>
-										</div>
-									</div>
-								</li>
-							</cfloop>
-						</ol>
-					</li>
-					<li class="list-group-item">
-						<h4>Files with worst coverage:</h4>
-						<ol class="list-group">
-							<cfloop query="stats.qryFilesWorstCoverage">
-								<cfset percentage = round( percCoverage*100 )>
-								<li class="list-group-item list-group-item-#codeBrowser.percentToContextualClass( percentage )#">
-									<span class="col-9">#trimmedFilePath#</span>
-									<div class=" col-3 d-inline-flex float-right">
-										<div class="progress position-relative w-100">
-											<div class="progress-bar bg-#codeBrowser.percentToContextualClass( percentage )#" role="progressbar" style="width: #percentage#%" aria-valuenow="#percentage#" aria-valuemin="0" aria-valuemax="100"></div>
-											<div class="progress-bar bg-secondary" role="progressbar" style="width: #100-percentage#%" aria-valuenow="#100-percentage#" aria-valuemin="0" aria-valuemax="100"></div>
-											<span class="justify-content-center text-light d-flex position-absolute w-100">#percentage#% coverage</span>
-										</div>
-									</div>
-								</li>
-							</cfloop>
-						</ol>
-					</li>
-				</ul>
 			</div>
 		</div>
-
-
 	</cfif>
 </cfoutput>

--- a/system/reports/assets/simple.cfm
+++ b/system/reports/assets/simple.cfm
@@ -19,27 +19,27 @@
 	</cfif>
 
 	<div class="container-fluid my-3">
-		<!--- Filter and Coverage Modal--->
+		<!--- Filter--->
 		<div class="row mb-3 clearfix">
 			<div class="col-5">
 				<!--- Header --->
 				<p>TestBox v#testbox.getVersion()#</p>
 			</div>
 			<div class="col-7">
-
 				<input class="d-inline col-7 ml-2 form-control float-right mb-2" type="text" name="bundleFilter" id="bundleFilter" placeholder="Filter Bundles..." size="35">
-
-
 			</div>
 
 		</div>
 
 		<!--- Stats --->
-		<div class="list-group">
-			<cfif results.getCoverageEnabled()>
-				#testbox.getCoverageService().renderStats( results.getCoverageData() )#
-			</cfif>
 
+		<!--- Code Coverage Stats --->
+		<cfif results.getCoverageEnabled()>
+			#testbox.getCoverageService().renderStats( results.getCoverageData() )#
+		</cfif>
+
+		<div class="list-group">
+			<!--- Test Results Stats --->
 			<div class="list-group-item list-group-item-info" id="globalStats">
 
 				<div class="buttonBar">
@@ -67,88 +67,88 @@
 					</h5>
 				</cfif>
 			</div>
-		</div>
 
-		<div class="accordion" id="bundles">
+			<div class="accordion" id="bundles">
 
-			<!--- Bundle Info --->
-			<cfloop array="#variables.bundleStats#" index="thisBundle">
-				<!--- Skip if not in the includes list --->
-				<cfif len( url.testBundles ) and !listFindNoCase( url.testBundles, thisBundle.path )>
-					<cfcontinue>
-				</cfif>
-				<!--- Bundle div --->
-				<div class="card bundle" id="#thisBundle.path#" data-bundle="#thisBundle.path#">
-					<div class="card-header" id="header_#thisBundle.id#">
-						<h4 class="mb-0 clearfix">
-							<!--- bundle stats --->
-							<a class="alert-link" href="#variables.baseURL#&directory=#URLEncodedFormat( URL.directory )#&testBundles=#URLEncodedFormat( thisBundle.path )#&target=#URLEncodedFormat( thisBundle.path )#&opt_run=true" title="Run only this bundle">
-								#thisBundle.path# (#thisBundle.totalDuration# ms)
-							</a>
-							<button class="btn btn-link float-right py-0" type="button" data-toggle="collapse" data-target="##details_#thisBundle.id#" aria-expanded="false" aria-controls="details_#thisBundle.id#">
-								<i class="arrow" aria-hidden="true"></i>
-							</button>
-						</h4>
-						<div class="float-right">
-							<span class="specStatus  m-1 btn btn-sm btn-success passed" data-status="passed" data-bundleid="#thisBundle.id#">Pass: #thisBundle.totalPass#</span>
-							<span class="specStatus  m-1 btn btn-sm btn-warning failed" data-status="failed" data-bundleid="#thisBundle.id#">Failures: #thisBundle.totalFail#</span>
-							<span class="specStatus  m-1 btn btn-sm btn-danger error" data-status="error" data-bundleid="#thisBundle.id#">Errors: #thisBundle.totalError#</span>
-							<span class="specStatus  m-1 btn btn-sm btn-secondary skipped" data-status="skipped" data-bundleid="#thisBundle.id#">Skipped: #thisBundle.totalSkipped#</span>
-							<span class="reset m-1 btn btn-sm btn-dark" title="Clear status filters">Reset</span>
+				<!--- Bundle Info --->
+				<cfloop array="#variables.bundleStats#" index="thisBundle">
+					<!--- Skip if not in the includes list --->
+					<cfif len( url.testBundles ) and !listFindNoCase( url.testBundles, thisBundle.path )>
+						<cfcontinue>
+					</cfif>
+					<!--- Bundle div --->
+					<div class="card bundle" id="#thisBundle.path#" data-bundle="#thisBundle.path#">
+						<div class="card-header" id="header_#thisBundle.id#">
+							<h4 class="mb-0 clearfix">
+								<!--- bundle stats --->
+								<a class="alert-link" href="#variables.baseURL#&directory=#URLEncodedFormat( URL.directory )#&testBundles=#URLEncodedFormat( thisBundle.path )#&target=#URLEncodedFormat( thisBundle.path )#&opt_run=true" title="Run only this bundle">
+									#thisBundle.path# (#thisBundle.totalDuration# ms)
+								</a>
+								<button class="btn btn-link float-right py-0" type="button" data-toggle="collapse" data-target="##details_#thisBundle.id#" aria-expanded="false" aria-controls="details_#thisBundle.id#">
+									<i class="arrow" aria-hidden="true"></i>
+								</button>
+							</h4>
+							<div class="float-right">
+								<span class="specStatus  m-1 btn btn-sm btn-success passed" data-status="passed" data-bundleid="#thisBundle.id#">Pass: #thisBundle.totalPass#</span>
+								<span class="specStatus  m-1 btn btn-sm btn-warning failed" data-status="failed" data-bundleid="#thisBundle.id#">Failures: #thisBundle.totalFail#</span>
+								<span class="specStatus  m-1 btn btn-sm btn-danger error" data-status="error" data-bundleid="#thisBundle.id#">Errors: #thisBundle.totalError#</span>
+								<span class="specStatus  m-1 btn btn-sm btn-secondary skipped" data-status="skipped" data-bundleid="#thisBundle.id#">Skipped: #thisBundle.totalSkipped#</span>
+								<span class="reset m-1 btn btn-sm btn-dark" title="Clear status filters">Reset</span>
+							</div>
+							<h5 class="d-inline-block mt-2">
+								<span>Suites:<span class="badge badge-info ml-1">#thisBundle.totalSuites#</span></span>
+								<span class="ml-3">Specs:<span class="badge badge-info ml-1">#thisBundle.totalSpecs#</span></span>
+							</h5>
 						</div>
-						<h5 class="d-inline-block mt-2">
-							<span>Suites:<span class="badge badge-info ml-1">#thisBundle.totalSuites#</span></span>
-							<span class="ml-3">Specs:<span class="badge badge-info ml-1">#thisBundle.totalSpecs#</span></span>
-						</h5>
-					</div>
-					<div id="details_#thisBundle.id#" class="collapse details-panel show" aria-labelledby="header_#thisBundle.id#" data-bundle="#thisBundle.path#">
-						<div class="card-body">
-							<ul class="suite list-group">
-								<!--- Global Error --->
-								<cfif !isSimpleValue( thisBundle.globalException )>
-									<li class="list-group-item list-group-item-danger">
-										<span class="h5">
-											<strong>Global Bundle Exception</strong>
-										</span>
-										<button class="btn btn-link float-right py-0 expand-collapse collapsed" id="btn_globalException_#thisBundle#" onclick="toggleDebug( 'globalException_#thisBundle#' )" title="Show more information">
-											<i class="arrow" aria-hidden="true"></i>
-										</button>
-										<div class="my-2 pl-4 debugdata" style="display:none;" data-specid="globalException_#thisBundle#">
-											<cfdump var="#thisBundle.globalException#" />
-										</div>
-									</li>
-								</cfif>
+						<div id="details_#thisBundle.id#" class="collapse details-panel show" aria-labelledby="header_#thisBundle.id#" data-bundle="#thisBundle.path#">
+							<div class="card-body">
+								<ul class="suite list-group">
+									<!--- Global Error --->
+									<cfif !isSimpleValue( thisBundle.globalException )>
+										<li class="list-group-item list-group-item-danger">
+											<span class="h5">
+												<strong>Global Bundle Exception</strong>
+											</span>
+											<button class="btn btn-link float-right py-0 expand-collapse collapsed" id="btn_globalException_#thisBundle#" onclick="toggleDebug( 'globalException_#thisBundle#' )" title="Show more information">
+												<i class="arrow" aria-hidden="true"></i>
+											</button>
+											<div class="my-2 pl-4 debugdata" style="display:none;" data-specid="globalException_#thisBundle#">
+												<cfdump var="#thisBundle.globalException#" />
+											</div>
+										</li>
+									</cfif>
 
-								<!-- Iterate over bundle suites -->
-								<cfloop array="#thisBundle.suiteStats#" index="suiteStats">
-									<ul class="suite list-group #statusPlusBootstrapClass( suiteStats.status )#" data-bundleid="#thisBundle.id#">
-										#genSuiteReport( suiteStats, thisBundle )#
-									</ul>
-								</cfloop>
+									<!-- Iterate over bundle suites -->
+									<cfloop array="#thisBundle.suiteStats#" index="suiteStats">
+										<ul class="suite list-group #statusPlusBootstrapClass( suiteStats.status )#" data-bundleid="#thisBundle.id#">
+											#genSuiteReport( suiteStats, thisBundle )#
+										</ul>
+									</cfloop>
 
-								<!--- Debug Panel --->
-								<cfif arrayLen( thisBundle.debugBuffer )>
-									<li class="list-group-item list-group-item-info">
-										<span class="alert-link h5">
-											<strong>Debug Stream</strong>
-										</span>
-										<button class="btn btn-link float-right py-0 expand-collapse collapsed" id="btn_#thisBundle.id#" onclick="toggleDebug( '#thisBundle.id#' )" title="Toggle the test debug stream">
-											<i class="arrow" aria-hidden="true"></i>
-										</button>
-										<div class="my-2 pl-4 debugdata" style="display:none;" data-specid="#thisBundle.id#">
-											<p>The following data was collected in order as your tests ran via the <em>debug()</em> method:</p>
-											<cfloop array="#thisBundle.debugBuffer#" index="thisDebug">
-												<h6>#thisDebug.label#</h6>
-												<cfdump var="#thisDebug.data#" label="#thisDebug.label# - #dateFormat( thisDebug.timestamp, " short" )# at #timeFormat( thisDebug.timestamp, "full" )#" top="#thisDebug.top#" />
-											</cfloop>
-										</div>
-									</li>
-								</cfif>
-							</ul>
+									<!--- Debug Panel --->
+									<cfif arrayLen( thisBundle.debugBuffer )>
+										<li class="list-group-item list-group-item-info">
+											<span class="alert-link h5">
+												<strong>Debug Stream</strong>
+											</span>
+											<button class="btn btn-link float-right py-0 expand-collapse collapsed" id="btn_#thisBundle.id#" onclick="toggleDebug( '#thisBundle.id#' )" title="Toggle the test debug stream">
+												<i class="arrow" aria-hidden="true"></i>
+											</button>
+											<div class="my-2 pl-4 debugdata" style="display:none;" data-specid="#thisBundle.id#">
+												<p>The following data was collected in order as your tests ran via the <em>debug()</em> method:</p>
+												<cfloop array="#thisBundle.debugBuffer#" index="thisDebug">
+													<h6>#thisDebug.label#</h6>
+													<cfdump var="#thisDebug.data#" label="#thisDebug.label# - #dateFormat( thisDebug.timestamp, " short" )# at #timeFormat( thisDebug.timestamp, "full" )#" top="#thisDebug.top#" />
+												</cfloop>
+											</div>
+										</li>
+									</cfif>
+								</ul>
+							</div>
 						</div>
 					</div>
-				</div>
-			</cfloop>
+				</cfloop>
+			</div>
 		</div>
 	</div>
 </cfoutput>

--- a/system/reports/assets/simple.cfm
+++ b/system/reports/assets/simple.cfm
@@ -35,7 +35,7 @@
 
 		<!--- Code Coverage Stats --->
 		<cfif results.getCoverageEnabled()>
-			#testbox.getCoverageService().renderStats( results.getCoverageData() )#
+			#testbox.getCoverageService().renderStats( results.getCoverageData(), false )#
 		</cfif>
 
 		<div class="list-group">
@@ -85,7 +85,7 @@
 									#thisBundle.path# (#thisBundle.totalDuration# ms)
 								</a>
 								<button class="btn btn-link float-right py-0" type="button" data-toggle="collapse" data-target="##details_#thisBundle.id#" aria-expanded="false" aria-controls="details_#thisBundle.id#">
-									<i class="arrow" aria-hidden="true"></i>
+									<span class="arrow" aria-hidden="true"></span>
 								</button>
 							</h4>
 							<div class="float-right">
@@ -110,7 +110,7 @@
 												<strong>Global Bundle Exception</strong>
 											</span>
 											<button class="btn btn-link float-right py-0 expand-collapse collapsed" id="btn_globalException_#thisBundle#" onclick="toggleDebug( 'globalException_#thisBundle#' )" title="Show more information">
-												<i class="arrow" aria-hidden="true"></i>
+												<span class="arrow" aria-hidden="true"></span>
 											</button>
 											<div class="my-2 pl-4 debugdata" style="display:none;" data-specid="globalException_#thisBundle#">
 												<cfdump var="#thisBundle.globalException#" />
@@ -132,7 +132,7 @@
 												<strong>Debug Stream</strong>
 											</span>
 											<button class="btn btn-link float-right py-0 expand-collapse collapsed" id="btn_#thisBundle.id#" onclick="toggleDebug( '#thisBundle.id#' )" title="Toggle the test debug stream">
-												<i class="arrow" aria-hidden="true"></i>
+												<span class="arrow" aria-hidden="true"></span>
 											</button>
 											<div class="my-2 pl-4 debugdata" style="display:none;" data-specid="#thisBundle.id#">
 												<p>The following data was collected in order as your tests ran via the <em>debug()</em> method:</p>
@@ -325,7 +325,7 @@ code {
 							<cfif structKeyExists( local.thisSpec, "message" )>
 								- <strong>#encodeForHTML( local.thisSpec.message )#</strong></a>
 								<button class="btn btn-link float-right py-0 expand-collapse collapsed" id="btn_#local.thisSpec.id#" onclick="toggleDebug( '#local.thisSpec.id#' )" title="Show more information">
-									<i class="arrow" aria-hidden="true"></i>
+									<span class="arrow" aria-hidden="true"></span>
 								</button>
 							</cfif>
 						</div>


### PR DESCRIPTION
Separate the Code Coverage Stats panel from the Test Results Panel 
Add an html section and scripts to coverageStats.cfm to make it self-contained in case in needs to be rendered independently from the simple.cfm reporter.