### PR TITLE
Convert location protocol to SSL

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,7 +1,7 @@
 {
     "name":"TestBox",
     "version":"@build.version@+@build.number@",
-    "location":"http://downloads.ortussolutions.com/ortussolutions/testbox/@build.version@/testbox-@build.version@.zip",
+    "location":"https://downloads.ortussolutions.com/ortussolutions/testbox/@build.version@/testbox-@build.version@.zip",
     "author":"Ortus Solutions <info@ortussolutions.com>",
     "slug":"testbox",
     "type":"testing",


### PR DESCRIPTION
Necessary for certain security software which does not follow the redirects in place for `downloads.ortussolutions.com`