### PR TITLE
WIP: Add support for async bundles

### DIFF
--- a/system/runners/HTMLRunner.cfm
+++ b/system/runners/HTMLRunner.cfm
@@ -18,6 +18,8 @@
 <cfparam name="url.coverageWhitelist"				default="">
 <cfparam name="url.coverageBlacklist"				default="/testbox">
 
+<cfparam name="url.asyncBundles"                    default="false">
+
 <cfscript>
 // prepare for tests for bundles or directories
 testbox = new testbox.system.TestBox(
@@ -46,7 +48,7 @@ if( len( url.directory ) ){
 }
 
 // Run Tests using correct reporter
-results = testbox.run( reporter=url.reporter );
+results = testbox.run( reporter=url.reporter, asyncBundles=url.asyncBundles );
 
 // Write TEST.properties in report destination path.
 if( url.propertiesSummary ){


### PR DESCRIPTION
Async bundles means running each test cfc in its own thread.

Right now it creates issues with code coverage not reporting correctly.  It also is not joining back up correctly on at least `adobe@2016`.