### PR TITLE
When the key existed notToHaveKey wasn't failing

### DIFF
--- a/system/Assertion.cfc
+++ b/system/Assertion.cfc
@@ -363,7 +363,7 @@ component {
 			arguments.key
 				.listToArray()
 				.filter( function( thisKey ){
-					return !structKeyExists( target, arguments.thisKey );
+					return structKeyExists( target, arguments.thisKey );
 				} )
 				.len() > 0
 		){

--- a/tests/specs/EdgeCases.cfc
+++ b/tests/specs/EdgeCases.cfc
@@ -64,6 +64,18 @@ component extends="testbox.system.BaseSpec" {
 			}
 		});
 
+		describe( "When testing a key does not exists", function(){
+			var data = {name="luis", awesome=true};
+			it( "should pass when the key does not exist", function(){
+				expect(	data ).notToHaveKey( "age" );
+			});
+			it( "should fail when the key does exist", function(){
+				expect( function(){ 
+					expect(	data ).notToHaveKey( "name" );
+				} ).toThrow( type = "TestBox.AssertionFailed" );
+			});
+		});
+
 	}
 
 	private function myFakeClosure(){	


### PR DESCRIPTION
This was flagged on the boxteam slack channel by Scott Conklin.

To clarify, this worked as expected:

```
var foo = {"one": 1, "two": 2};
expect(foo).ToHaveKey("two"); // pass - as expected
expect(foo).notToHaveKey("three"); // pass - as expected
```

However, this was not working as expected:

```
var foo = {"one": 1, "two": 2};
expect(foo).notToHaveKey("two"); // is passing - should fail
```

Added test to prove it and flipped the logic.

Tried to stick to house style with formatting and seed data :)