### PR TITLE
Add return this to key()

### DIFF
--- a/system/Assertion.cfc
+++ b/system/Assertion.cfc
@@ -341,6 +341,7 @@ component {
 		){
 			fail( arguments.message );
 		}
+		return this;
 	}
 
 	/**


### PR DESCRIPTION
When chaining assertions in an xUnit spec, we get a value must be initialized error if we chain anything off of key(). By adding this line, method chaining will work as expected. Let me know if that doesn't make sense, or if you see any issues with it.

Example:
$assert.lengthOf( results, 3 )
    .key( results, "foo" )
    .key( results, "bar" );