### PR TITLE
Fix missing raw_trace in simple.cfm

### DIFF
--- a/system/reports/assets/simple.cfm
+++ b/system/reports/assets/simple.cfm
@@ -534,7 +534,7 @@ code {
 											<div>
 												<pre>#left( local.thisSpec.failDetail, 2500 )#</pre>
 											</div>
-										<cfelse>
+										<cfelseif structKeyExists( local.thisSpec.failOrigin[ 1 ], "raw_trace" )>
 											<!--- Raw Trace --->
 											<div>
 												<pre>#local.thisSpec.failOrigin[ 1 ].raw_trace#</pre>


### PR DESCRIPTION
If there's a syntax error in a dependent file called from a spec, this can cause the local.thisSpec.failOrigin[ 1 ] to not have a raw_trace key, which results in a generic CF 500 error in ACF (11 & 2018 were tested). By adding a key exists check, this allows the report to render and display the exception structure allowing much easier debugging of the syntax error.