### PR TITLE
var scoping

### DIFF
--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -987,7 +987,7 @@ component {
 
 		// Execute it
 		arrayEach( reverseTree, function( item ){
-			item.beforeEach( currentSpec = spec.name, data = item.beforeEachData );
+			arguments.item.beforeEach( currentSpec = spec.name, data = arguments.item.beforeEachData );
 		} );
 
 		// execute beforeEach()

--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -516,7 +516,7 @@ component {
 		}
 
 		// Attach this spec to the incoming context array of specs
-		arrayAppend( variables.this.$suitesReverseLookup[ variables.this.$suiteContext ].specs, spec );
+		arrayAppend( this.$suitesReverseLookup[ this.$suiteContext ].specs, spec );
 
 		// Are we focused?
 		if( arguments.focused ){
@@ -1075,7 +1075,7 @@ component {
 		required spec,
 		closureIndex = 1
 	){
-		local.thread = {};
+		// TODO note, this isn't actually the thread scope
 		thread.closures = arguments.closures;
 		thread.suite    = arguments.suite;
 		thread.spec     = arguments.spec;

--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -516,7 +516,7 @@ component {
 		}
 
 		// Attach this spec to the incoming context array of specs
-		arrayAppend( this.$suitesReverseLookup[ this.$suiteContext ].specs, spec );
+		arrayAppend( variables.this.$suitesReverseLookup[ variables.this.$suiteContext ].specs, spec );
 
 		// Are we focused?
 		if( arguments.focused ){
@@ -1075,15 +1075,16 @@ component {
 		required spec,
 		closureIndex = 1
 	){
+		local.thread = {};
 		thread.closures = arguments.closures;
 		thread.suite    = arguments.suite;
 		thread.spec     = arguments.spec;
 
 		// Get closure data from stack and pop it
-		var nextClosure = thread.closures[ closureIndex ];
+		var nextClosure = thread.closures[ arguments.closureIndex ];
 
 		// Check if we have more in the stack or empty
-		if ( arrayLen( thread.closures ) == closureIndex ) {
+		if ( arrayLen( thread.closures ) == arguments.closureIndex ) {
 			// Return the closure of execution for a single spec ONLY
 			return function(){
 				// Execute the body of the spec
@@ -1092,8 +1093,9 @@ component {
 		}
 
 		// Get next Spec in stack
-		var nextSpecInfo = thread.closures[ ++closureIndex ];
+		var nextSpecInfo = thread.closures[ ++arguments.closureIndex ];
 		// Return generated closure
+		var _closureIndex = arguments.closureIndex;
 		return function(){
 			nextClosure.body(
 				spec = {
@@ -1102,7 +1104,7 @@ component {
 						thread.closures,
 						thread.suite,
 						thread.spec,
-						closureIndex
+						_closureIndex
 					),
 					data   : nextSpecInfo.data,
 					labels : nextSpecInfo.labels,
@@ -1435,7 +1437,7 @@ component {
 
 	// Around Stub
 	function aroundStub( spec ){
-		spec.body( spec.data );
+		arguments.spec.body( arguments.spec.data );
 	}
 
 	/**

--- a/system/MockBox.cfc
+++ b/system/MockBox.cfc
@@ -565,7 +565,7 @@ Description		:
 		<cffunction name="decorateMock" access="private" returntype="void" hint="Decorate a mock object" output="false" >
 			<cfargument name="target"  type="any" required="true" hint="The target object">
 			<cfscript>
-				var obj = target;
+				var obj = arguments.target;
 
 				// Mock Method Results Holder
 				obj._mockResults 	= structnew();

--- a/system/TestBox.cfc
+++ b/system/TestBox.cfc
@@ -237,7 +237,7 @@ component accessors="true"{
 			testSpecs   = arguments.testSpecs
 		);
 
-		coverageService.beginCapture();
+		variables.coverageService.beginCapture();
 
 		// iterate and run the test bundles
 		for( var thisBundlePath in variables.bundles ){
@@ -371,14 +371,14 @@ component accessors="true"{
 		try{
 			var response = getPageContext().getResponse();
 
-			response.addHeader( "x-testbox-totalDuration", javaCast( "string", results.getTotalDuration() ) );
-			response.addHeader( "x-testbox-totalBundles", javaCast( "string", results.getTotalBundles() ) );
-			response.addHeader( "x-testbox-totalSuites", javaCast( "string", results.getTotalSuites() ) );
-			response.addHeader( "x-testbox-totalSpecs", javaCast( "string", results.getTotalSpecs() ) );
-			response.addHeader( "x-testbox-totalPass", javaCast( "string", results.getTotalPass() ) );
-			response.addHeader( "x-testbox-totalFail", javaCast( "string", results.getTotalFail() ) );
-			response.addHeader( "x-testbox-totalError", javaCast( "string", results.getTotalError() ) );
-			response.addHeader( "x-testbox-totalSkipped", javaCast( "string", results.getTotalSkipped() ) );
+			response.addHeader( "x-testbox-totalDuration", javaCast( "string", arguments.results.getTotalDuration() ) );
+			response.addHeader( "x-testbox-totalBundles", javaCast( "string", arguments.results.getTotalBundles() ) );
+			response.addHeader( "x-testbox-totalSuites", javaCast( "string", arguments.results.getTotalSuites() ) );
+			response.addHeader( "x-testbox-totalSpecs", javaCast( "string", arguments.results.getTotalSpecs() ) );
+			response.addHeader( "x-testbox-totalPass", javaCast( "string", arguments.results.getTotalPass() ) );
+			response.addHeader( "x-testbox-totalFail", javaCast( "string", arguments.results.getTotalFail() ) );
+			response.addHeader( "x-testbox-totalError", javaCast( "string", arguments.results.getTotalError() ) );
+			response.addHeader( "x-testbox-totalSkipped", javaCast( "string", arguments.results.getTotalSkipped() ) );
 		} catch( Any e ){
 			writeLog( type="error",
 					  text="Error sending TestBox headers: #e.message# #e.detail# #e.stackTrace#",

--- a/system/coverage/CoverageService.cfc
+++ b/system/coverage/CoverageService.cfc
@@ -39,13 +39,13 @@ component accessors="true" {
 	function init( coverageOptions={} ) {
 
 	  	// Default options
-	  	variables.coverageOptions = setDefaultOptions( coverageOptions );
-	  	variables.coverageEnabled = coverageOptions.enabled;
+	  	variables.coverageOptions = setDefaultOptions( arguments.coverageOptions );
+	  	variables.coverageEnabled = variables.coverageOptions.enabled;
 
 	  	// If disabled in config, go no further
-	  	if( coverageEnabled ) {
+	  	if( variables.coverageEnabled ) {
 			variables.coverageGenerator = new data.CoverageGenerator();
-			variables.coverageEnabled = coverageGenerator.configure();
+			variables.coverageEnabled = variables.coverageGenerator.configure();
 		}
 
 		return this;

--- a/system/reports/assets/simple.cfm
+++ b/system/reports/assets/simple.cfm
@@ -446,7 +446,7 @@ code {
 
 <cffunction name="statusToBootstrapClass" output="false">
 	<cfargument name="status">
-	<cfset bootstrapClass = "">
+	<cfset var bootstrapClass = "">
 	<cfif lcase( arguments.status ) eq "failed">
 		<cfset bootstrapClass = "warning">
 	<cfelseif lcase( arguments.status ) eq "error">
@@ -461,7 +461,7 @@ code {
 
 <cffunction name="statusToIcon" output="false">
 	<cfargument name="status">
-	<cfset icon = "">
+	<cfset var icon = "">
 	<cfif lcase( arguments.status ) eq "failed">
 		<cfset icon = '<i class="fas fa-exclamation-triangle"></i>'>
 	<cfelseif lcase( arguments.status ) eq "error">
@@ -480,10 +480,10 @@ code {
 	<cfargument name="bundleStats">
 	<cfsavecontent variable="local.report">
 		<cfoutput>
-			<li class="list-group-item #suiteStats.status#" data-bundleid="#suiteStats.bundleID#">
+			<li class="list-group-item #arguments.suiteStats.status#" data-bundleid="#arguments.suiteStats.bundleID#">
 				<!--- Suite Results --->
 				<a
-					class="alert-link text-#statusToBootstrapClass( suiteStats.status )#"
+					class="alert-link text-#statusToBootstrapClass( arguments.suiteStats.status )#"
 					title="Total: #arguments.suiteStats.totalSpecs# Passed:#arguments.suiteStats.totalPass# Failed:#arguments.suiteStats.totalFail# Errors:#arguments.suiteStats.totalError# Skipped:#arguments.suiteStats.totalSkipped#"
 					href="#variables.baseURL#&directory=#URLEncodedFormat( URL.directory )#&testSuites=#URLEncodedFormat( arguments.suiteStats.name )#&testBundles=#URLEncodedFormat( arguments.bundleStats.path )#&opt_run=true&coverageEnabled=false"
 				>

--- a/system/runners/BDDRunner.cfc
+++ b/system/runners/BDDRunner.cfc
@@ -166,7 +166,7 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 			// prepare threaded names
 			var threadNames = [];
 			// threaded variables just in case some suite is async and another is not.
-			local.thread = {};
+			// TODO note, this isn't actually the thread scope			
 			thread.testResults 	= arguments.testResults;
 			thread.suiteStats  	= suiteStats;
 			thread.target 		= arguments.target;

--- a/system/runners/BDDRunner.cfc
+++ b/system/runners/BDDRunner.cfc
@@ -166,6 +166,7 @@ component extends="testbox.system.runners.BaseRunner" implements="testbox.system
 			// prepare threaded names
 			var threadNames = [];
 			// threaded variables just in case some suite is async and another is not.
+			local.thread = {};
 			thread.testResults 	= arguments.testResults;
 			thread.suiteStats  	= suiteStats;
 			thread.target 		= arguments.target;

--- a/system/runners/BaseRunner.cfc
+++ b/system/runners/BaseRunner.cfc
@@ -201,7 +201,7 @@ component{
 			return true;
 		}
 		// All xUnit test methods must start or end with the term, "test".
-		return( !! reFindNoCase( "(^test|test$)", methodName ) );
+		return( !! reFindNoCase( "(^test|test$)", arguments.methodName ) );
 	}
 
 	/**

--- a/system/util/MixerUtil.cfc
+++ b/system/util/MixerUtil.cfc
@@ -46,8 +46,8 @@ Description :
 		<cflock name="mixerUtil.#instance.system.identityHashCode(arguments.CFC)#" type="exclusive" timeout="15" throwontimeout="true">
 			<cfif NOT structKeyExists(arguments.CFC, "$mixed")>
 			<cfscript>
-				for( udf in instance.mixins ){
-					arguments.CFC[udf] = instance.mixins[udf];
+				for( udf in variables.instance.mixins ){
+					arguments.CFC[udf] = variables.instance.mixins[udf];
 				}
 				arguments.CFC.$mixed = true;
 			</cfscript>

--- a/system/util/Util.cfc
+++ b/system/util/Util.cfc
@@ -126,7 +126,7 @@ component{
 		if( structKeyExists( arguments.metadata, "functions" ) ){
 
 			for( var thisFunction in arguments.metadata.functions ){
-				if( structKeyExists( thisFunction, annotation ) ){
+				if( structKeyExists( thisFunction, arguments.annotation ) ){
 					arrayAppend( lifecycleMethods, thisFunction );
 				}
 			}


### PR DESCRIPTION
Lucee is reporting a lot of implicit variable access in BaseSpec, which I haven't really touched


C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 83 | variables | THIS | 224
-- | -- | -- | -- | --
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 84 | variables | THIS | 224
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 85 | variables | THIS | 112
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 94 | variables | THIS | 4
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 95 | variables | THIS | 4
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 96 | variables | THIS | 2
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 170 | variables | CLOSURESTUB | 114
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 173 | variables | CLOSURESTUB | 114
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 176 | variables | AROUNDSTUB | 114
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 198 | variables | THIS | 398
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 200 | variables | THIS | 398
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 201 | variables | THIS | 199
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 204 | variables | THIS | 199
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 205 | variables | THIS | 398
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 208 | variables | THIS | 597
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 214 | variables | THIS | 199
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 215 | variables | THIS | 199
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 217 | variables | THIS | 199
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 218 | variables | THIS | 199
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 222 | variables | THIS | 199
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 223 | variables | THIS | 199
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 243 | variables | THIS | 199
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 245 | variables | THIS | 199
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 485 | variables | THIS | 932
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 503 | variables | THIS | 932
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 519 | variables | THIS | 1280
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 527 | variables | THIS | 932
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 599 | variables | THIS | 4
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 720 | variables | THIS | 861
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 730 | variables | THIS | 287
C:\lucee\tomcat\webapps\ROOT\testbox\system\BaseSpec.cfc | 883 | variables | THIS | 160

