### PR TITLE
Fix the coverage % in HTML visualizer TESTBOX-278

### DIFF
--- a/test-visualizer/index.html
+++ b/test-visualizer/index.html
@@ -151,7 +151,7 @@
 												<div class="progress-bar bg-secondary" role="progressbar" style="width: ${100 - totalCoveragePercent}%" aria-valuenow="${100 - totalCoveragePercent}" aria-valuemin="0" aria-valuemax="100">
 												</div>
 												<span class="justify-content-center text-light d-flex position-absolute w-100" style="line-height: 1.25rem; font-size: 1.2rem;">
-													17.8% coverage
+													${totalCoveragePercent}% coverage
 												</span>
 											</div>
 										</div>


### PR DESCRIPTION
https://ortussolutions.atlassian.net/browse/TESTBOX-278

The coverage percentage currently shown is hard-coded to 17.8%.