### PR TITLE
Lucee 4.5 doesn't like 2 arg valueArray() :(

### DIFF
--- a/system/coverage/stats/coverageStats.cfm
+++ b/system/coverage/stats/coverageStats.cfm
@@ -66,8 +66,8 @@
 				</div>
 			</div>
 
-			<cfset bestCoverageHasCoveredFiles = ArraySum(ValueArray(stats.qryFilesBestCoverage, "percCoverage")) GT 0 >
-			<cfset worstCoverageHasCoveredFiles = ArraySum(ValueArray(stats.qryFilesWorstCoverage, "percCoverage")) GT 0 >
+			<cfset bestCoverageHasCoveredFiles = ArraySum(listToArray(valueList(stats.qryFilesBestCoverage.percCoverage))) GT 0 >
+			<cfset worstCoverageHasCoveredFiles = ArraySum(listToArray(valueList(stats.qryFilesWorstCoverage.percCoverage))) GT 0 >
 
 			<div id="coverage-stats" class="debugdata mt-2 collapse" data-specid="coverageStats">
 				<ul class="list-group">


### PR DESCRIPTION
lucee 4.5 doesn't like valueArray() with 2 arguments, replacing it with valueList() and listToArray() works in lucee 4.5+ & adobe cf 2016+