### PR TITLE
Updating serializeJSON to never use JSON Prefix

### DIFF
--- a/system/coverage/browser/CodeBrowser.cfc
+++ b/system/coverage/browser/CodeBrowser.cfc
@@ -93,7 +93,7 @@ component accessors=true {
 				return ( value > 0 ) ? "success" : "danger";
 			} );
 			var percentage              = numberFormat( fileData.percCoverage * 100, "9.9" );
-			var lineNumbersBGColorsJSON = serializeJSON( lineNumbersBGColors );
+			var lineNumbersBGColorsJSON = serializeJSON( lineNumbersBGColors, false, false );
 			var fileContents            = fileRead( fileData.filePath );
 			var levelsFromRoot          = fileData.relativeFilePath.listLen( "/" );
 			var relPathToRoot           = repeatString( "../", levelsFromRoot - 1 );


### PR DESCRIPTION
Turning on the JSON prefix adds the prefix to the string which the JavaScript does not identify as valid JSON. This results in no color-coded lines in the coverage report