### PR TITLE
Fix HTTP Status Headers Being Removed By Reporters

### DIFF
--- a/system/TestBox.cfc
+++ b/system/TestBox.cfc
@@ -170,8 +170,14 @@ component accessors="true" {
 		var results      = runRaw( argumentCollection = arguments );
 		// store latest results
 		variables.result = results;
+
+		var report = produceReport( results );
+
+		// set status headers again incase they were removed by one of the reporters
+		sendStatusHeaders( results );
+
 		// return report
-		return produceReport( results );
+		return report;
 	}
 
 	/**


### PR DESCRIPTION
### Change summary

- I added a call to `setStatusHeaders` after the report has been generated

### Context

I ran into an issue when using the following command in a CI platform.

```
box testbox run outputFile=test-results/junit.xml reporter=junit
```
It was not failing the build when my tests failed. I looked into it and found that the commandbox command was not returning a failing exit code because it checks some http status header to determine if the tests failed or not. 

It looks like this change removes the http headers for certain reports. The change here will add them back after the report is generated.

https://github.com/Ortus-Solutions/TestBox/commit/7a75421a92762547e13e8da3466dbdc393d173d2#diff-ee95bf579700102699738cc8291077b1

