### PR TITLE
Make coverageStats.cfm compatible with ACF11

### DIFF
--- a/system/coverage/stats/coverageStats.cfm
+++ b/system/coverage/stats/coverageStats.cfm
@@ -66,9 +66,9 @@
 				</div>
 			</div>
 
-			<cfset bestCoverageHasCoveredFiles = ArraySum(ValueArray(stats.qryFilesBestCoverage, "percCoverage")) GT 0 >
-			<cfset worstCoverageHasCoveredFiles = ArraySum(ValueArray(stats.qryFilesWorstCoverage, "percCoverage")) GT 0 >
-
+			<cfset bestCoverageHasCoveredFiles = ArraySum(ListToArray(ValueList(stats.qryFilesBestCoverage.percCoverage))) GT 0 >
+			<cfset worstCoverageHasCoveredFiles = ArraySum(ListToArray(ValueList(stats.qryFilesWorstCoverage.percCoverage))) GT 0 >
+			
 			<div id="coverage-stats" class="debugdata mt-2 collapse" data-specid="coverageStats">
 				<ul class="list-group">
 					<cfif bestCoverageHasCoveredFiles >


### PR DESCRIPTION
ACF11 does not have `ValueArray()`, but it's easy to achieve the same result with existing functions.

Note: if the best or worst covered files have commas in their names, this code could break, but have you ever seen a comma in a code filename?