### PR TITLE
Escape </script> tags in coverage output so that the output isn't broken

### DIFF
--- a/system/coverage/browser/CodeBrowser.cfc
+++ b/system/coverage/browser/CodeBrowser.cfc
@@ -99,6 +99,9 @@ component accessors=true {
 			var relPathToRoot           = repeatString( "../", levelsFromRoot - 1 );
 			var brush                   = right( fileData.relativeFilePath, 4 ) == ".cfm" ? "coldfusion" : "javascript";
 
+			// Escape closing script tags to avoid breaking out of code display early
+			fileContents = REReplace(fileContents, '</script>', '&lt;/script>', 'all');
+
 			savecontent variable="local.fileTemplate" {
 				include "templates/file.cfm";
 			}


### PR DESCRIPTION
With a </script> tag in the source file, the test coverage output broke on that line, looking like this:
![Screen Shot 2021-05-27 at 2 22 25 PM](https://user-images.githubusercontent.com/198711/119877446-0bda7d80-bef7-11eb-9191-fa9c6dc3adfe.png)

This PR escapes </script> tags so that the coverage output is no longer broken.