### PR TITLE
TESTBOX-327

### DIFF
--- a/system/coverage/stats/CoverageStats.cfc
+++ b/system/coverage/stats/CoverageStats.cfc
@@ -42,7 +42,6 @@ component accessors=true {
 			SELECT	sum( numCoveredLines ) as sumCoveredLines ,
 					sum( numExecutableLines ) as sumExecutableLines
 			FROM qryData
-			GROUP BY filePath
 			",
 			{},
 			{ dbtype : "query" }


### PR DESCRIPTION
Fix the query that gets totals across all files.  Right now it groups by individual files, so the vars we set a few lines below it only represent the coverage stats for a single file rather than all files.