### PR TITLE
Catch spec errors with no type

### DIFF
--- a/system/reports/ANTJUnitReporter.cfc
+++ b/system/reports/ANTJUnitReporter.cfc
@@ -188,7 +188,7 @@ return;
 			}
 			case "error": {
 				out.append(
-					"<error type=""#encodeForXMLAttribute( stats.error.type )#"" message=""#encodeForXMLAttribute( stats.error.message )#""><![CDATA[
+					"<error type=""#encodeForXMLAttribute( !isNull( stats.error.type ) ? stats.error.type : '' )#"" message=""#encodeForXMLAttribute( stats.error.message )#""><![CDATA[
 					#stats.error.stackTrace.toString()#
 					]]></error>"
 				);


### PR DESCRIPTION
For some reason, certain test spec errors don't have a `type` set. (This may be ACF2016-specific?) This PR defends against a null `error.type` so the report will still build out.

See https://github.com/coldbox-modules/cborm/pull/43/checks?check_run_id=3508905432#step:9:463:


```
Output formats detected (json,antjunit), building out reports...
=> json : /home/runner/work/cborm/cborm/test-harness/tests/results/test-results.json

ERROR (5.4.0+00432)

key [TYPE] doesn't exist


/system/modules_app/testbox-commands/testbox/system/reports/ANTJUnitReporter.cfc: line 189
187: 			case "error": {
188: 				out.append(
189: 					"<error type=""#xmlFormat( stats.error.type )#"" message=""#xmlFormat( stats.error.message )#""><![CDATA[
190: 					#stats.error.stackTrace.toString()#
191: 					]]></error>"
called from /system/modules_app/testbox-commands/testbox/system/reports/ANTJUnitReporter.cfc: line 138
called from /system/modules_app/testbox-commands/testbox/system/reports/ANTJUnitReporter.cfc: line 81
called from /system/modules_app/testbox-commands/testbox/system/reports/ANTJUnitReporter.cfc: line 36
called from /system/modules_app/testbox-commands/commands/testbox/run.cfc: line 310
```