### PR TITLE
toHaveLength param should be numeric

### DIFF
--- a/system/Expectation.cfc
+++ b/system/Expectation.cfc
@@ -349,7 +349,7 @@ component accessors="true" {
 	 * @length  The length to check
 	 * @message The message to send in the failure
 	 */
-	function toHaveLength( required string length, message = "" ){
+	function toHaveLength( required numeric length, message = "" ){
 		arguments.target = this.actual;
 		if ( this.isNot ) {
 			variables.assert.notLengthOf( argumentCollection = arguments );


### PR DESCRIPTION
The `toHaveLength` length argument should have data type of numeric
This change does not impact usage
Requesting as VSCode extension cflsp flags data incorrect type when you do:
`expect( x ).toHaveLength( 1 );`

Extension:
https://marketplace.visualstudio.com/items?itemName=DavidRogers.cflsp
