### PR TITLE
🐛 FIX: Don't assume TagContext has length

### DIFF
--- a/system/reports/assets/simple.cfm
+++ b/system/reports/assets/simple.cfm
@@ -560,7 +560,7 @@ code {
 									</cfif>
 
 									<!--- If it's an error, show the last snapshot --->
-									<cfif !isNull( local.thisSpec.error.tagContext ) >
+									<cfif !isNull( local.thisSpec.error.tagContext ) && arrayLen( local.thisSpec.error.tagContext ) >
 										<cfset var thisContext = local.thisSpec.error.tagContext[ 1 ]>
 										<!--- Template --->
 										<div style="margin-bottom: 5px">

--- a/tests/specs/AbstractClass.cfc
+++ b/tests/specs/AbstractClass.cfc
@@ -1,4 +1,4 @@
-abstract     component {
+abstract       component {
 
 	function init(){
 		// This is an abstract class


### PR DESCRIPTION
Resolves an error in a certain StackOverflowError where the TagContext is an empty array. Thus breaking the error reporting. 😢

![error: "array index 1 is out of range" in testbox simple reporter](https://user-images.githubusercontent.com/8106227/180304324-c415a593-17d8-471c-8c7d-1befa1e27b80.png)