### PR TITLE
🐛 FIX: Use separate notToThrow method to fix default regex

### DIFF
--- a/system/Expectation.cfc
+++ b/system/Expectation.cfc
@@ -353,20 +353,28 @@ component accessors="true" {
 
 	/**
 	 * Assert that the passed in function will throw an exception
-	 *
 	 * @type    Match this type with the exception thrown
 	 * @regex   Match this regex against the message of the exception
 	 * @message The message to send in the failure
 	 */
 	function toThrow( type = "", regex = ".*", message = "" ){
 		arguments.target = this.actual;
-		if ( this.isNot ) {
-			variables.assert.notThrows( argumentCollection = arguments );
-		} else {
-			variables.assert.throws( argumentCollection = arguments );
-		}
+		variables.assert.throws( argumentCollection = arguments );
 		return this;
 	}
+
+	/**
+	 * Assert that the passed in function will NOT throw an exception
+	 * @type    Match this type with the exception thrown
+	 * @regex   Match this regex against the message of the exception
+	 * @message The message to send in the failure
+	 */
+	function notToThrow( type = "", regex = "", message = "" ){
+		arguments.target = this.actual;
+		variables.assert.notThrows( argumentCollection = arguments );
+		return this;
+	}
+
 
 	/**
 	 * Assert that the passed in actual number or date is expected to be close to it within +/- a passed delta and optional datepart

--- a/tests/specs/AbstractClass.cfc
+++ b/tests/specs/AbstractClass.cfc
@@ -1,4 +1,4 @@
-abstract         component {
+abstract           component {
 
 	function init(){
 		// This is an abstract class

--- a/tests/specs/BDDTest.cfc
+++ b/tests/specs/BDDTest.cfc
@@ -384,11 +384,11 @@ component extends="testbox.system.BaseSpec" {
 			} );
 			it( "will fail when no regex provided if any exception occurs", function(){
 				// Exception Inception!
-				expect( function() {
+				expect( function(){
 					expect( function(){
 						throw( type = "AnyException" );
 					} ).notToThrow();
-				}).toThrow( "TestBox.AssertionFailed" );
+				} ).toThrow( "TestBox.AssertionFailed" );
 			} );
 		} );
 	}

--- a/tests/specs/BDDTest.cfc
+++ b/tests/specs/BDDTest.cfc
@@ -382,6 +382,14 @@ component extends="testbox.system.BaseSpec" {
 					throw( type = "DifferentException" );
 				} ).notToThrow( "FooException" );
 			} );
+			it( "will fail when no regex provided if any exception occurs", function(){
+				// Exception Inception!
+				expect( function() {
+					expect( function(){
+						throw( type = "AnyException" );
+					} ).notToThrow();
+				}).toThrow( "TestBox.AssertionFailed" );
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Resolves TESTBOX-357.