### PR TITLE
TESTBOX-362 Added Support for Test Subdirectories 

### DIFF
--- a/test-browser/index.cfm
+++ b/test-browser/index.cfm
@@ -30,9 +30,9 @@
 	qResults = directoryList( targetPath, false, "query", "", "name" );
 	// Get the back path
 	if( len( url.path ) ){
-		backPath = ListToArray( url.path, "\" );
+		backPath = ListToArray( url.path, "/" );
 		backPath.pop();
-		backPath = ArrayToList( backPath, "\" );
+		backPath = ArrayToList( backPath, "/" );
 	}
 	// TestBox Assets
 	ASSETS_DIR = expandPath( "/testbox/system/reports/assets" );
@@ -109,7 +109,7 @@
 						<cfif qResults.type eq "Dir">
 							<a
 								class="btn btn-secondary btn-sm my-1"
-								href="index.cfm?path=#urlEncodedFormat( url.path & "\" & qResults.name )#"
+								href="index.cfm?path=#urlEncodedFormat( url.path & "/" & qResults.name )#"
 							>
 								&##x271A; #qResults.name#
 							</a>

--- a/test-browser/index.cfm
+++ b/test-browser/index.cfm
@@ -108,7 +108,7 @@
 						<cfif qResults.type eq "Dir">
 							<a
 								class="btn btn-secondary btn-sm my-1"
-								href="index.cfm?path=#urlEncodedFormat( url.path & qResults.name )#"
+								href="index.cfm?path=#urlEncodedFormat( url.path & "\" & qResults.name )#"
 							>
 								&##x271A; #qResults.name#
 							</a>

--- a/test-browser/index.cfm
+++ b/test-browser/index.cfm
@@ -30,8 +30,9 @@
 	qResults = directoryList( targetPath, false, "query", "", "name" );
 	// Get the back path
 	if( len( url.path ) ){
-		backPath = replacenocase( url.path, listLast( url.path, "/" ), "" );
-		backPath = reReplace( backpath, "/$", "" );
+		backPath = ListToArray( url.path, "\" );
+		backPath.pop();
+		backPath = ArrayToList( backPath, "\" );
 	}
 	// TestBox Assets
 	ASSETS_DIR = expandPath( "/testbox/system/reports/assets" );


### PR DESCRIPTION
Added support to add subdirectories into the tests/TEST_TYPE folders.
The back button has also been updated to support this functionality. 
Previous
![image](https://user-images.githubusercontent.com/11895741/192174372-ac7156f7-7e4b-4f9c-8010-0a5161050460.png)


Current
![image](https://user-images.githubusercontent.com/11895741/192174333-277f2c70-2b28-4140-844d-8a4afd7f758f.png)
