### PR TITLE
Add more info to the ANTJunit reporter

### DIFF
--- a/system/reports/ANTJUnitReporter.cfc
+++ b/system/reports/ANTJUnitReporter.cfc
@@ -176,9 +176,34 @@ return;
 		switch ( stats.status ) {
 			case "failed": {
 				out.append(
-					"<failure message=""#encodeForXMLAttribute( stats.failMessage )#""><![CDATA[
-					#stats.failorigin.toString()#
-					]]></failure>"
+					"<failure message=""#encodeForXMLAttribute( stats.failMessage )#""><![CDATA["
+				);
+				if ( isArray(stats.failOrigin) && arrayLen(stats.failOrigin ) ) {
+					for ( var thisContext in stats.failOrigin ) {
+						if ( findNoCase( arguments.bundleStats.path, reReplace( thisContext.template, "(/|\\)", ".", "all" ) ) ) {
+							if ( structKeyExists( thisContext, "codePrintPlain" ) ) {
+								out.append(
+									"#thisContext.codePrintPlain#"
+								);
+							}
+							out.append(
+								"#thisContext.template#:#thisContext.line#"
+							);
+						}
+					}
+				}
+				if ( len( stats.failDetail ) ) {
+					out.append(
+						"Failure Details: #stats.failDetail#"
+					);
+				}
+				if ( len( stats.failExtendedInfo ) ) {
+					out.append(
+						"Failure Extended Info: #stats.failExtendedInfo#"
+					);
+				}
+				out.append(
+					"]]></failure>"
 				);
 				break;
 			}

--- a/tests/specs/AbstractClass.cfc
+++ b/tests/specs/AbstractClass.cfc
@@ -1,4 +1,4 @@
-abstract             component {
+abstract               component {
 
 	function init(){
 		// This is an abstract class

--- a/tests/specs/AbstractClass.cfc
+++ b/tests/specs/AbstractClass.cfc
@@ -1,4 +1,4 @@
-abstract           component {
+abstract             component {
 
 	function init(){
 		// This is an abstract class


### PR DESCRIPTION
Add more info to the ANTJUnit reporter.  

We are using it with Gitlab-ci and the output in the Gitlab UI is really ugly.

Before:

![image](https://user-images.githubusercontent.com/73978/202390100-2fce88b3-ccaa-48a6-b72f-e9b20448b454.png)


After the PR:

![image](https://user-images.githubusercontent.com/73978/202389636-90044015-403d-4978-b84e-3af68e2d4c83.png)
