### PR TITLE
🐛 FIX: Encode exception messages for HTML

### DIFF
--- a/system/reports/assets/simple.cfm
+++ b/system/reports/assets/simple.cfm
@@ -237,7 +237,7 @@
 															>
 																<i class="fas fa-plus-square plus-minus"></i>
 															</button>
-															<div>#thisBundle.globalException.Message#</div>
+															<div>#encodeForHtml( thisBundle.globalException.Message )#</div>
 															<div class="bg-light p-2 ">
 																<cfif arrayLen( thisBundle.globalException.TagContext ) && structKeyExists( thisBundle.globalException.TagContext[ 1 ], "codePrintHTML" )>
 																	<code>#thisBundle.globalException.TagContext[ 1 ].codePrintHTML#</code>
@@ -606,10 +606,10 @@ code {
 										<!--- StackTrace --->
 										<h4>Failure StackTrace</h4>
 										<cfif len( local.thisSpec.failStackTrace )>
-											<pre>#local.thisSpec.failStackTrace#</pre>
+											<pre>#encodeForHTML( local.thisSpec.failStackTrace )#</pre>
 										</cfif>
 										<cfif !isNull( local.thisSpec.error.stackTrace )>
-											<pre>#local.thisSpec.error.stackTrace#</pre>
+											<pre>#encodeForHTML( local.thisSpec.error.stackTrace )#</pre>
 										</cfif>
 
 										<!--- Extended Info --->


### PR DESCRIPTION
## Description

An HTML needle-in-haystack check will output the raw HTML if the expectation fails. This can break the testbox runner output, particularly if there's a `<base>` tag in the output. (Ask me how I know. 😁)

## Jira Issues

https://ortussolutions.atlassian.net/browse/TESTBOX-369


## Type of change

- [x] Bug Fix

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
