### PR TITLE
Update BDDRunner.cfc

### DIFF
--- a/system/runners/BDDRunner.cfc
+++ b/system/runners/BDDRunner.cfc
@@ -153,7 +153,7 @@ component
 						e,
 						arguments.target,
 						arguments.testResults,
-						thisSuite
+						thisSuite?:""
 					]
 				);
 			}

--- a/system/runners/BDDRunner.cfc
+++ b/system/runners/BDDRunner.cfc
@@ -153,7 +153,7 @@ component
 						e,
 						arguments.target,
 						arguments.testResults,
-						thisSuite?:""
+						isNull( thisSuite ) ? {} : thisSuite
 					]
 				);
 			}


### PR DESCRIPTION
## Description

The variable thisSuite isn't defined if the for loop in the try/catch is never reached before the error.
Found this would occur when the model threw an error.

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Jira Issues

All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

> Bug Tracker: https://ortussolutions.atlassian.net/jira/software/c/projects/TESTBOX/issues


## Type of change

- [ ] Bug Fix


## Checklist

- [ ] New and existing unit tests pass locally with my changes
