### PR TITLE
TESTBOX-407 switch from java method addAll() to cfml array.Append()

### DIFF
--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -988,11 +988,11 @@ component {
 			var consolidatedLabels = arguments.spec.labels;
 			var md                 = getMetadata( this );
 			param md.labels        = "";
-			consolidatedLabels.addAll( listToArray( md.labels ) );
+			consolidatedLabels.append( listToArray( md.labels, true ) );
 			// Build labels from nested suites, so suites inherit from parent suite labels
 			var parentSuite = arguments.suite;
 			while ( !isSimpleValue( parentSuite ) ) {
-				consolidatedLabels.addAll( parentSuite.labels );
+				consolidatedLabels.append( parentSuite.labels, true );
 				parentSuite = parentSuite.parentref;
 			}
 

--- a/system/TestBox.cfc
+++ b/system/TestBox.cfc
@@ -406,16 +406,16 @@ component accessors="true" {
 
 		// Verify URL conventions for bundle, suites and specs exclusions.
 		if ( !isNull( url.testBundles ) ) {
-			testBundles.addAll( listToArray( urlDecode( url.testBundles ) ) );
+			testBundles.append( listToArray( urlDecode( url.testBundles ) ), true );
 		}
 		if ( !isNull( url.testSuites ) ) {
-			arguments.testSuites.addAll( listToArray( urlDecode( url.testSuites ) ) );
+			arguments.testSuites.append( listToArray( urlDecode( url.testSuites ) ), true );
 		}
 		if ( !isNull( url.testSpecs ) ) {
-			arguments.testSpecs.addAll( listToArray( urlDecode( url.testSpecs ) ) );
+			arguments.testSpecs.append( listToArray( urlDecode( url.testSpecs ) ), true );
 		}
 		if ( !isNull( url.testMethod ) ) {
-			arguments.testSpecs.addAll( listToArray( urlDecode( url.testMethod ) ) );
+			arguments.testSpecs.append( listToArray( urlDecode( url.testMethod ) ), true );
 		}
 
 		// Using a directory runner?

--- a/system/compat/framework/TestSuite.cfc
+++ b/system/compat/framework/TestSuite.cfc
@@ -19,13 +19,13 @@ component accessors="true" {
 
 	remote function addTest( required componentName, required method ){
 		arrayAppend( variables.bundles, arguments.componentName );
-		variables.testSpecs.addAll( listToArray( arguments.method ) );
+		variables.testSpecs.append( listToArray( arguments.method ), true );
 		return this;
 	}
 
 	remote function add( required componentName, required methods ){
 		arrayAppend( variables.bundles, arguments.componentName );
-		variables.testSpecs.addAll( listToArray( arguments.methods ) );
+		variables.testSpecs.append( listToArray( arguments.methods ), true );
 		return this;
 	}
 
@@ -36,7 +36,7 @@ component accessors="true" {
 
 	remote function run( testMethod = "" ){
 		if ( len( arguments.testMethod ) ) {
-			variables.testSpecs.addAll( listToArray( arguments.testMethod ) );
+			variables.testSpecs.append( listToArray( arguments.testMethod ), true );
 		}
 		return new Results( variables.bundles, variables.testSpecs );
 	}

--- a/system/runners/BDDRunner.cfc
+++ b/system/runners/BDDRunner.cfc
@@ -197,7 +197,7 @@ component
 		// Build labels from nested suites, so suites inherit from parent suite labels
 		var parentSuite        = arguments.suite;
 		while ( !isSimpleValue( parentSuite ) ) {
-			consolidatedLabels.addAll( parentSuite.labels );
+			consolidatedLabels.append( parentSuite.labels, true );
 			parentSuite = parentSuite.parentref;
 		}
 

--- a/tests/runners/mxunit/compat-testsuites.cfm
+++ b/tests/runners/mxunit/compat-testsuites.cfm
@@ -1,6 +1,6 @@
 <cfsetting showdebugoutput="false" >
 <cfset suite = new testbox.system.compat.framework.TestSuite().TestSuite()>
-<cfset suite.addAll( "testbox.tests.specs.MXUnitCompatTest" )>
+<cfset suite.append( "testbox.tests.specs.MXUnitCompatTest" )>
 <cfset r = suite.run()>
 <cfoutput>#r.getResultsOutput( reporter="simple" )#</cfoutput>
 


### PR DESCRIPTION
Simply switch to using the cfml `array.append()` instead of the java method `array.addAll()` via reflection

https://ortussolutions.atlassian.net/browse/TESTBOX-407
