### PR TITLE
The true flag should be the 2nd param of append to concatenate the ar…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.1] - 2025-01-10
+
 ## [6.0.1] - 2024-12-05
 
 ## [6.0.0] - 2024-09-27
@@ -42,8 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - TESTBOX-400 Drop Adobe 2018 support
 
-[Unreleased]: https://github.com/Ortus-Solutions/TestBox/compare/v6.0.1...HEAD
+[Unreleased]: https://github.com/aliaspooryorik/TestBox/compare/v6.0.1...HEAD
 
-[6.0.1]: https://github.com/Ortus-Solutions/TestBox/compare/v6.0.0...v6.0.1
+[6.0.1]: https://github.com/aliaspooryorik/TestBox/compare/v6.0.1...v6.0.1
+
 
 [6.0.0]: https://github.com/Ortus-Solutions/TestBox/compare/bc7774b4cc681cd8dfab08b2f3bba26a75f5601b...v6.0.0

--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -988,7 +988,7 @@ component {
 			var consolidatedLabels = arguments.spec.labels;
 			var md                 = getMetadata( this );
 			param md.labels        = "";
-			consolidatedLabels.append( listToArray( md.labels, true ) );
+			consolidatedLabels.append( listToArray( md.labels ), true );
 			// Build labels from nested suites, so suites inherit from parent suite labels
 			var parentSuite = arguments.suite;
 			while ( !isSimpleValue( parentSuite ) ) {


### PR DESCRIPTION
## Type of change

- [x] Bug Fix

## Bug Tracker

https://ortussolutions.atlassian.net/browse/TESTBOX-410

## Description

When calling the runner with `url.excludes`  then it errors in `testbox/system/runners/BaseRunner.cfc:36` with:

```
coldfusion.runtime.ArrayUtil$InvalidArgumentforArrayFindNoCase: "Valid datatypes in array are String|Boolean|Number.
```

This is because it is added the array as an element instead of concatenating them.


