### PR TITLE
flag should be 2nd arg of append to concatenate arrays

### DIFF
--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -988,7 +988,7 @@ component {
 			var consolidatedLabels = arguments.spec.labels;
 			var md                 = getMetadata( this );
 			var mdLabels           = md.labels ?: "";
-			consolidatedLabels.append( listToArray( mdLabels, true ) );
+			consolidatedLabels.append( listToArray( mdLabels ), true );
 			// Build labels from nested suites, so suites inherit from parent suite labels
 			var parentSuite = arguments.suite;
 			while ( !isSimpleValue( parentSuite ) ) {


### PR DESCRIPTION
## Type of change

- [x] Bug Fix

## Jira Issue

https://ortussolutions.atlassian.net/browse/TESTBOX-410

## Description

When calling the runner with url.excludes then it errors in testbox/system/runners/BaseRunner.cfc:36 with:

```
coldfusion.runtime.ArrayUtil$InvalidArgumentforArrayFindNoCase: 
"Valid datatypes in array are String|Boolean|Number.
```

This is because it is adding the array as an element instead of concatenating them.

## Jira Issues

All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

> Bug Tracker: https://ortussolutions.atlassian.net/jira/software/c/projects/TESTBOX/issues


