### PR TITLE
Update TestCase.cfc to include an XML output param value

### DIFF
--- a/system/compat/framework/TestCase.cfc
+++ b/system/compat/framework/TestCase.cfc
@@ -45,6 +45,10 @@ component extends="testbox.system.BaseSpec" {
 				arguments.output = "junit";
 				break;
 			}
+			case "xml": {
+				arguments.output = "xml";
+				break;
+			}
 			case "query":
 			case "array": {
 				arguments.output = "raw";


### PR DESCRIPTION
When using tests that run on processes that use SAML to output XML, this fails because it needs to use the XML reporter. This is useful for output that needs to be of mime type application/xml

## Description

When hitting a URL like:

https://foo.server.com/app-test/unit/testcases/saml/test_post_abstractsamlparser.cfc?method=runtestremote&output=xml&testmethod=test__isPost_should_return_true_when_called_in_http_post

Currently an error is thrown, because our application requires valid XML output, in the form of the mime type `application/xml`
This can be resolved by adding a connector in:

system\compat\framework\TestCase.cfc

To the XML reporter.

**Please note that all PRs must have tests attached to them**

Here is the helper function, where the current version of TestBox fails:

_webroot\app-test\unit\testcases\saml\test_abstractsamlparser.cfc_

```
	<cffunction order="200" name="test__isPost_should_return_true_when_called_in_http_post" returntype="void" access="public">
		<cfset funcsTested["_isPost"] = 1>

		<cfset postURL  = _getProtocolAndDomain()>
		<cfset postURL  = postURL & "app-test/unit/testcases/saml/test_post_abstractsamlparser.cfc?method=runtestremote&output=xml">
		<cfset postURL  = postURL & "&testmethod=test__isPost_should_return_true_when_called_in_http_post">
		<cfset formParams = { SAMLRequest="", relayState="" }>

		<cfset _callHttpPost(postURL, formParams)>
	</cffunction>
```

_webroot\app-test\unit\testcases\saml\test_abstractsamlparser.cfc_

```
        <!--- this helper is used to create an HTTP POST for tests that need it --->
	<cffunction name="_callHttpPost" returntype="void" access="private">
		<cfargument name="postURL"    required="true"  type="string" hint="the URL of the test including the method to be run" >
		<cfargument name="formParams" required="false" type="struct" default="#{}#" hint="a structure of form parameters to pass" >

		<cfhttp method="POST" url="#arguments.postURL#" result="result">
			<cfloop collection="#arguments.formParams#" item="param">
				<cfhttpparam type="formField" name="#param#" value="#arguments.formParams[param]#" >
			</cfloop>
		</cfhttp>

		<cftry>
			<cfset detail = xmlParse(trim(result.filecontent))> // ERROR OCCURS HERE
			<cfcatch>
				<!--- these lines are to aid debugging and allow a cf_com_utl_dump this is added to the called mxunit test to be shown here --->
				<cfdump var="#Arguments#">
				<cfdump var="#result#" label="Returned value is not valid XML. test_AbstractSamlParser._callHttpPost">
				<cfabort>
			</cfcatch>
		</cftry>

		<cfset responseList = "trace,message,error,content">
		<cfset testResult = {}>

		<cfloop index="i" list="#responseList#">
			<cfset testResult[i] = xmlSearch(trim(result.filecontent), "/test_results/test_case/results/#i#")[1].xmlText ?: "">
		</cfloop>
		<cfif testResult.error neq "">
			<cfset errorText = xmlParse(testResult.error).xmlRoot.xmlText>
			<cfset errorHTML = replace(errorText, "|", "<br />", "all")>
			<cfset fail(errorHTML)>
			<cfoutput>(test_AbstractSamlParser._callHttpPost)</cfoutput>
			<cfabort>
		</cfif>

		<cfset assertEquals("Passed", testResult.message, "")>
	</cffunction>
```

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Jira Issues

All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

> Bug Tracker: https://ortussolutions.atlassian.net/jira/software/c/projects/TESTBOX/issues

## Type of change

Please delete options that are not relevant.

- [ ] Improvement

## Checklist

- [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
