### PR TITLE
Fix cgi scope reference in CLI (boxlang) environments

### DIFF
--- a/system/reports/ANTJUnitReporter.cfc
+++ b/system/reports/ANTJUnitReporter.cfc
@@ -62,6 +62,7 @@ component extends="BaseReporter" {
 
 			// build test suite header
 			// cfformat-ignore-start
+			var hostname = cgi.remote_host ?: "";
 			buffer.append(
 				"<testsuite
 				tests=""#thisBundle.totalSpecs#""
@@ -70,7 +71,7 @@ component extends="BaseReporter" {
 				skipped=""#thisBundle.totalSkipped#""
 				time=""#thisBundle.totalDuration / 1000#""
 				timestamp=""#dateFormat( now(), "yyyy-mm-dd" )#T#timeFormat( now(), "HH:mm:ss" )#""
-				hostname=""#encodeForXMLAttribute( cgi.remote_host )#""
+				hostname=""#encodeForXMLAttribute( hostname )#""
 				package=""#encodeForXMLAttribute( thisBundle.path )#""
 				name=""#encodeForXMLAttribute( thisBundle.name )#""
 				>"

--- a/system/reports/JUnitReporter.cfc
+++ b/system/reports/JUnitReporter.cfc
@@ -90,6 +90,7 @@ component extends="BaseReporter" {
 
 			// build test suite header
 			// cfformat-ignore-start
+			var hostname = cgi.remote_host ?: "";
 			out.append(
 				"<testsuite
 				name=""#fullName#""
@@ -99,7 +100,7 @@ component extends="BaseReporter" {
 				time=""#thisSuite.totalDuration / 1000#""
 				skipped=""#thisSuite.totalSkipped#""
 				timestamp=""#dateFormat( now(), "mm/dd/yy" )# #timeFormat( now(), "medium" )#""
-				hostname=""#encodeForXMLAttribute( cgi.remote_host )#""
+				hostname=""#encodeForXMLAttribute( hostname )#""
 				package=""#encodeForXMLAttribute( arguments.bundleStats.path )#""
 				>"
 			);


### PR DESCRIPTION
When running testbox on boxlang CLI, no `cgi` scope exists. Thus we need to fall back to an empty string for the `hostname` junit attribute.

## Description

Please include a summary of the changes and which issue(s) is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Jira Issues

[TESTBOX-429](https://ortussolutions.atlassian.net/browse/TESTBOX-429)

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix


[TESTBOX-429]: https://ortussolutions.atlassian.net/browse/TESTBOX-429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ