### PR TITLE
server-lucee@7.json - incorrectly references Lucce v6

### DIFF
--- a/server-lucee@7.json
+++ b/server-lucee@7.json
@@ -1,5 +1,5 @@
 {
-    "name":"testbox-lucee@6",
+    "name":"testbox-lucee@7",
     "force":true,
     "openbrowser":"false",
     "web":{
@@ -9,8 +9,8 @@
         }
     },
     "app":{
-        "cfengine":"lucee@6",
-        "serverHomeDirectory":".engine/lucee6"
+        "cfengine":"lucee@7",
+        "serverHomeDirectory":".engine/lucee7"
     },
     "cfconfig":{
         "file":".cfconfig.json"


### PR DESCRIPTION
## Description

server-lucee@7.json incorrectly references Lucee v6

## Jira Issues
https://github.com/Ortus-Solutions/TestBox/issues/187

## Type of change
- [X] Bug Fix

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)