### PR TITLE
Add streaming test results via Server-Sent Events (SSE)

### DIFF
--- a/cfml/tests/runner.cfm
+++ b/cfml/tests/runner.cfm
@@ -12,6 +12,9 @@
 <cfparam name="url.editor" 				default="vscode">
 <cfparam name="url.bundlesPattern" 		default="*Spec*.cfc|*Test*.cfc|*Spec*.bx|*Test*.bx">
 
+<!--- Streaming mode: streams results via Server-Sent Events (SSE) for real-time progress --->
+<cfparam name="url.streaming"						default="false" type="boolean">
+
 <!--- Code Coverage requires FusionReactor --->
 <cfparam name="url.coverageEnabled"					default="true">
 <cfparam name="url.coveragePathToCapture"			default="#expandPath( '/root' )#">
@@ -22,5 +25,11 @@
 <!--- Enable batched code coverage reporter, useful for large test bundles which require spreading over multiple testbox run commands. --->
 <!--- <cfparam name="url.isBatched"						default="false"> --->
 
-<!--- Include the TestBox HTML Runner --->
-<cfinclude template="/testbox/system/runners/HTMLRunner.cfm" >
+<!--- Include the appropriate runner based on streaming mode --->
+<cfif url.streaming>
+	<!--- Stream results in real-time via SSE --->
+	<cfinclude template="/testbox/system/runners/StreamingRunner.cfm">
+<cfelse>
+	<!--- Traditional batch results --->
+	<cfinclude template="/testbox/system/runners/HTMLRunner.cfm">
+</cfif>

--- a/server-boxlang-cfml@1.json
+++ b/server-boxlang-cfml@1.json
@@ -1,8 +1,8 @@
 {
-	"name":"testbox-boxlang-cfml@1",
-	"force":true,
-	"openBrowser":false,
-	"web":{
+    "name":"testbox-boxlang-cfml@1",
+    "force":true,
+    "openBrowser":false,
+    "web":{
         "directoryBrowsing":true,
         "http":{
             "port":"49616"
@@ -14,7 +14,7 @@
     },
     "JVM":{
         "javaVersion":"openjdk21_jre",
-		"args": "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8888"
+        "args":"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8888"
     },
     "cfconfig":{
         "file":".cfconfig.json"

--- a/system/runners/BDDRunner.cfc
+++ b/system/runners/BDDRunner.cfc
@@ -380,6 +380,11 @@ component
 				if ( arguments.suite.asyncAll ) {
 					thread action="join" name="#arrayToList( threadNames )#" {
 					};
+
+					// Drain any queued streaming events from async spec execution
+					if ( structKeyExists( arguments.callbacks, "onAsyncDrain" ) ) {
+						arguments.callbacks.onAsyncDrain();
+					}
 				}
 			}
 			// end isDirectMatch else block

--- a/system/runners/StreamingRunner.cfm
+++ b/system/runners/StreamingRunner.cfm
@@ -1,0 +1,101 @@
+<cfsetting showDebugOutput="false">
+<cfsetting requesttimeout="99999999">
+<!---
+	Copyright Since 2005 TestBox Framework by Luis Majano and Ortus Solutions, Corp
+	www.ortussolutions.com
+	---
+	Streaming Test Runner - Streams test results via Server-Sent Events (SSE)
+	This runner outputs real-time test progress as SSE events, allowing CLI tools
+	like CommandBox to display incremental progress during test execution.
+
+	Usage: Add streaming=true to your runner URL parameters
+	Example: /tests/runner.cfm?streaming=true&directory=tests.specs
+--->
+
+<!--- URL Parameters - same as HTMLRunner.cfm --->
+<cfparam name="url.directory" 						default="">
+<cfparam name="url.recurse" 						default="true" type="boolean">
+<cfparam name="url.bundles" 						default="">
+<cfparam name="url.labels" 							default="">
+<cfparam name="url.excludes" 						default="">
+<cfparam name="url.bundlesPattern" 					default="*.bx|*.cfc">
+
+<!--- Coverage parameters --->
+<cfparam name="url.coverageEnabled"					default="false" type="boolean">
+<cfparam name="url.coverageSonarQubeXMLOutputPath"	default="">
+<cfparam name="url.coverageBrowserOutputDir"		default="">
+<cfparam name="url.coveragePathToCapture"			default="">
+<cfparam name="url.coverageWhitelist"				default="">
+<cfparam name="url.coverageBlacklist"				default="/testbox">
+<cfparam name="url.isBatched"						default="false">
+
+<cfscript>
+// Initialize streaming service and set SSE headers
+streamingService = new testbox.system.util.StreamingService();
+streamingService.initializeStream();
+
+// Create TestBox instance with same options as HTMLRunner
+testbox = new testbox.system.TestBox(
+	labels         = url.labels,
+	excludes       = url.excludes,
+	options        = {
+		coverage : {
+			enabled       : url.coverageEnabled,
+			pathToCapture : url.coveragePathToCapture,
+			whitelist     : url.coverageWhitelist,
+			blacklist     : url.coverageBlacklist,
+			isBatched     : url.isBatched,
+			sonarQube     : { XMLOutputPath : url.coverageSonarQubeXMLOutputPath },
+			browser       : { outputDir : url.coverageBrowserOutputDir }
+		}
+	},
+	bundlesPattern = url.bundlesPattern
+);
+
+// Add bundles if specified
+if ( len( url.bundles ) ) {
+	testbox.addBundles( url.bundles );
+}
+
+// Add directories if specified
+if ( len( url.directory ) ) {
+	for ( dir in listToArray( url.directory ) ) {
+		testbox.addDirectories( dir, url.recurse );
+	}
+}
+
+// Stream test run start event
+streamingService.streamEvent(
+	"testRunStart",
+	{
+		"timestamp"    : getTickCount(),
+		"totalBundles" : arrayLen( testbox.getBundles() ),
+		"labels"       : testbox.getLabels(),
+		"excludes"     : testbox.getExcludes()
+	}
+);
+
+// Create streaming callbacks
+callbacks = streamingService.createStreamingCallbacks();
+
+// Run tests with streaming callbacks
+results = testbox.runRaw( callbacks = callbacks );
+
+// Stream final event with full JSON results for outputFormats compatibility
+streamingService.streamEvent(
+	"testRunEnd",
+	{
+		"timestamp"     : getTickCount(),
+		"totalDuration" : results.getTotalDuration(),
+		"totalBundles"  : results.getTotalBundles(),
+		"totalSuites"   : results.getTotalSuites(),
+		"totalSpecs"    : results.getTotalSpecs(),
+		"totalPass"     : results.getTotalPass(),
+		"totalFail"     : results.getTotalFail(),
+		"totalError"    : results.getTotalError(),
+		"totalSkipped"  : results.getTotalSkipped(),
+		// Full results memento for outputFormats processing in testbox-cli
+		"results"       : results.getMemento( includeDebugBuffer = true )
+	}
+);
+</cfscript>

--- a/system/runners/StreamingRunner.cfm
+++ b/system/runners/StreamingRunner.cfm
@@ -79,7 +79,23 @@ streamingService.streamEvent(
 callbacks = streamingService.createStreamingCallbacks();
 
 // Run tests with streaming callbacks
-results = testbox.runRaw( callbacks = callbacks );
+try {
+	results = testbox.runRaw( callbacks = callbacks );
+} catch ( any e ) {
+	// Stream a fatal error event so SSE consumers can detect failure
+	streamingService.streamEvent(
+		"error",
+		{
+			"timestamp"  : getTickCount(),
+			"message"    : e.message,
+			"detail"     : e.detail ?: "",
+			"type"       : e.type ?: "Exception",
+			"tagContext" : e.tagContext ?: []
+		}
+	);
+
+	rethrow;
+}
 
 // Stream final event with full JSON results for outputFormats compatibility
 streamingService.streamEvent(

--- a/system/runners/UnitRunner.cfc
+++ b/system/runners/UnitRunner.cfc
@@ -341,6 +341,11 @@ component
 			if ( arguments.suite.asyncAll ) {
 				thread action="join" name="#arrayToList( threadNames )#" {
 				};
+
+				// Drain any queued streaming events from async spec execution
+				if ( structKeyExists( arguments.callbacks, "onAsyncDrain" ) ) {
+					arguments.callbacks.onAsyncDrain();
+				}
 			}
 
 			// All specs finalized, set suite status according to spec data

--- a/system/util/StreamingService.cfc
+++ b/system/util/StreamingService.cfc
@@ -30,7 +30,7 @@ component accessors="true" {
 	function streamEvent( required string eventType, required any data ){
 		writeOutput( "event: #arguments.eventType##chr( 10 )#" );
 		writeOutput( "data: #serializeJSON( arguments.data )##chr( 10 )##chr( 10 )#" );
-		cfflush();
+		cfflush(  );
 	}
 
 	/**

--- a/system/util/StreamingService.cfc
+++ b/system/util/StreamingService.cfc
@@ -5,11 +5,12 @@
  * Service for streaming test results via Server-Sent Events (SSE)
  * Compatible with Adobe ColdFusion 2021+, Lucee 5+, and BoxLang
  *
- * LIMITATION: When a test suite uses `asyncAll = true`, the `onSpecStart` and `onSpecEnd`
- * callbacks are invoked from within a cfthread block. Calling writeOutput and cfflush from
- * a child thread doesn't write to the parent request's HTTP response buffer, so spec events
- * for async suites will not be streamed in real-time. Bundle and suite start/end events will
- * still be streamed normally.
+ * When `asyncAll = true` is used in test suites, spec callbacks run inside cfthread blocks.
+ * Since writeOutput/cfflush from child threads don't write to the parent HTTP response buffer,
+ * this service supports a queue-based approach:
+ * - Events from thread contexts are automatically queued
+ * - Call drainQueue() from the main thread after threads join to flush queued events
+ * - Alternatively, enable queueMode to queue all events regardless of context
  */
 component accessors="true" {
 
@@ -20,6 +21,37 @@ component accessors="true" {
 		name   ="flushEnabled"
 		type   ="boolean"
 		default="true";
+
+	/**
+	 * Whether to queue events instead of streaming directly
+	 * When true, all events are queued regardless of thread context.
+	 * When false (default), events are auto-queued only when called from a thread.
+	 */
+	property
+		name   ="queueMode"
+		type   ="boolean"
+		default="false";
+
+	/**
+	 * Thread-safe event queue for async event buffering
+	 * Uses Java ConcurrentLinkedQueue for thread safety
+	 */
+	property name="eventQueue" type="any";
+
+	/**
+	 * Utility helper for thread detection
+	 */
+	property name="util" type="any";
+
+	/**
+	 * Constructor - initializes the thread-safe event queue
+	 */
+	function init(){
+		variables.eventQueue = createObject( "java", "java.util.concurrent.ConcurrentLinkedQueue" ).init();
+		variables.queueMode  = false;
+		variables.util       = new testbox.system.util.Util();
+		return this;
+	}
 
 	/**
 	 * Initialize streaming mode - sets SSE headers
@@ -50,12 +82,20 @@ component accessors="true" {
 
 	/**
 	 * Stream an SSE event to the client
+	 * When queueMode is enabled or when called from a thread context, events are queued
+	 * instead of streamed directly. Call drainQueue() from the main thread to flush.
 	 * Errors are caught and logged to prevent client disconnects from interrupting test execution.
 	 *
 	 * @eventType The type of event (e.g., bundleStart, specEnd)
 	 * @data      The data payload to send as JSON
 	 */
 	function streamEvent( required string eventType, required any data ){
+		// Queue events when queueMode is enabled OR when called from a thread context
+		if ( ( !isNull( variables.queueMode ) && variables.queueMode ) || variables.util.inThread() ) {
+			queueEvent( arguments.eventType, arguments.data );
+			return;
+		}
+
 		try {
 			writeOutput( formatSSEEvent( arguments.eventType, arguments.data ) );
 			// Only flush if enabled (disabled during unit testing to prevent response commit)
@@ -75,6 +115,81 @@ component accessors="true" {
 				// Ignore logging errors as well
 			}
 		}
+	}
+
+	/**
+	 * Queue an event for later streaming
+	 * This method is thread-safe and can be called from multiple threads concurrently.
+	 *
+	 * @eventType The type of event (e.g., specStart, specEnd)
+	 * @data      The data payload to queue
+	 */
+	function queueEvent( required string eventType, required any data ){
+		variables.eventQueue.add( {
+			"eventType" : arguments.eventType,
+			"data"      : arguments.data
+		} );
+	}
+
+	/**
+	 * Check if there are any queued events
+	 *
+	 * @return boolean True if there are events in the queue
+	 */
+	boolean function hasQueuedEvents(){
+		return !variables.eventQueue.isEmpty();
+	}
+
+	/**
+	 * Get all queued events without clearing the queue
+	 * Returns events in FIFO order.
+	 *
+	 * @return array Array of event structs with eventType and data keys
+	 */
+	array function getQueuedEvents(){
+		var events   = [];
+		var iterator = variables.eventQueue.iterator();
+		while ( iterator.hasNext() ) {
+			events.append( iterator.next() );
+		}
+		return events;
+	}
+
+	/**
+	 * Drain all queued events by streaming them to the client
+	 * This method should be called from the main thread after async specs complete.
+	 * The queue is cleared after draining.
+	 *
+	 * @return numeric The number of events that were drained
+	 */
+	numeric function drainQueue(){
+		var count = 0;
+		var event = variables.eventQueue.poll();
+
+		while ( !isNull( event ) ) {
+			try {
+				writeOutput( formatSSEEvent( event.eventType, event.data ) );
+				// Only flush if enabled (disabled during unit testing to prevent response commit)
+				if ( isNull( variables.flushEnabled ) || variables.flushEnabled ) {
+					cfflush(  );
+				}
+			} catch ( any e ) {
+				// Client may have disconnected - log and continue draining
+				try {
+					writeLog(
+						type = "information",
+						file = "testbox-streaming",
+						text = "StreamingService.drainQueue event failed: " & e.message
+					);
+				} catch ( any ignore ) {
+					// Ignore logging errors
+				}
+			}
+			count++;
+			event = variables.eventQueue.poll();
+		}
+
+		return count;
 	}
 
 	/**
@@ -199,6 +314,14 @@ component accessors="true" {
 						"error"          : currentSpec.error ?: {}
 					}
 				);
+			},
+			/**
+			 * Drain any queued events from async spec execution
+			 * This callback should be called by the runner after thread joins to flush
+			 * any events that were queued from thread contexts.
+			 */
+			"onAsyncDrain" : function(){
+				service.drainQueue();
 			}
 		};
 	}

--- a/system/util/StreamingService.cfc
+++ b/system/util/StreamingService.cfc
@@ -44,8 +44,9 @@ component accessors="true" {
 
 		return {
 			"onBundleStart" : function( target, testResults ){
-				// Note: Bundle stats are not yet created when onBundleStart fires
-				// We get bundle info from the target's metadata instead
+				// Note: Bundle stats (including the id) are not yet created when onBundleStart fires.
+				// We get bundle info from the target's metadata instead.
+				// Consumers should use 'path' to correlate bundleStart with bundleEnd events.
 				var targetMD    = getMetadata( arguments.target );
 				var annotations = targetMD.keyExists( "annotations" ) ? targetMD.annotations : targetMD;
 				var bundleName  = structKeyExists( annotations, "displayName" ) ? annotations.displayName : targetMD.name;

--- a/system/util/StreamingService.cfc
+++ b/system/util/StreamingService.cfc
@@ -66,15 +66,17 @@ component accessors="true" {
 		return {
 			"onBundleStart" : function( target, testResults ){
 				// Note: Bundle stats (including the id) are not yet created when onBundleStart fires.
-				// We get bundle info from the target's metadata instead.
-				// Consumers should use 'path' to correlate bundleStart with bundleEnd events.
+				// We generate a deterministic id from the path so consumers can correlate
+				// bundleStart with bundleEnd events.
 				var targetMD    = getMetadata( arguments.target );
 				var annotations = targetMD.keyExists( "annotations" ) ? targetMD.annotations : targetMD;
 				var bundleName  = structKeyExists( annotations, "displayName" ) ? annotations.displayName : targetMD.name;
+				var bundleId    = hash( targetMD.name );
 
 				service.streamEvent(
 					"bundleStart",
 					{
+						"id"        : bundleId,
 						"name"      : bundleName,
 						"path"      : targetMD.name,
 						"timestamp" : getTickCount()
@@ -82,19 +84,22 @@ component accessors="true" {
 				);
 			},
 			"onBundleEnd" : function( target, testResults ){
+				var targetMD  = getMetadata( arguments.target );
+				var bundleId  = hash( targetMD.name );
+
+				// Look up bundle stats by path (internal stats use a different id scheme)
 				var bundleStats   = arguments.testResults.getBundleStats();
-				var targetMD      = getMetadata( arguments.target );
 				var matchingStats = bundleStats.filter( function( s ){
 					return s.path == targetMD.name;
 				} );
 
-				// Prefer stats matched by bundle path; fall back to last entry if none found
+				// Prefer stats matched by path; fall back to last entry if none found
 				var current = matchingStats.len() ? matchingStats[ matchingStats.len() ] : bundleStats[ bundleStats.len() ];
 
 				service.streamEvent(
 					"bundleEnd",
 					{
-						"id"            : current.id,
+						"id"            : bundleId,
 						"name"          : current.name,
 						"path"          : current.path,
 						"totalDuration" : current.totalDuration,

--- a/system/util/StreamingService.cfc
+++ b/system/util/StreamingService.cfc
@@ -36,6 +36,19 @@ component accessors="true" {
 	}
 
 	/**
+	 * Format an SSE event as a string
+	 * Returns the properly formatted SSE event string without writing to output
+	 *
+	 * @eventType The type of event (e.g., bundleStart, specEnd)
+	 * @data      The data payload to serialize as JSON
+	 *
+	 * @return string The formatted SSE event string
+	 */
+	string function formatSSEEvent( required string eventType, required any data ){
+		return "event: #arguments.eventType##chr( 10 )#data: #serializeJSON( arguments.data )##chr( 10 )##chr( 10 )#";
+	}
+
+	/**
 	 * Stream an SSE event to the client
 	 * Errors are caught and logged to prevent client disconnects from interrupting test execution.
 	 *
@@ -44,8 +57,7 @@ component accessors="true" {
 	 */
 	function streamEvent( required string eventType, required any data ){
 		try {
-			writeOutput( "event: #arguments.eventType##chr( 10 )#" );
-			writeOutput( "data: #serializeJSON( arguments.data )##chr( 10 )##chr( 10 )#" );
+			writeOutput( formatSSEEvent( arguments.eventType, arguments.data ) );
 			// Only flush if enabled (disabled during unit testing to prevent response commit)
 			if ( isNull( variables.flushEnabled ) || variables.flushEnabled ) {
 				cfflush(  );

--- a/system/util/StreamingService.cfc
+++ b/system/util/StreamingService.cfc
@@ -1,0 +1,147 @@
+/**
+ * Copyright Since 2005 TestBox Framework by Luis Majano and Ortus Solutions, Corp
+ * www.ortussolutions.com
+ * ---
+ * Service for streaming test results via Server-Sent Events (SSE)
+ * Compatible with Adobe ColdFusion 2021+, Lucee 5+, and BoxLang
+ */
+component accessors="true" {
+
+	/**
+	 * Initialize streaming mode - sets SSE headers
+	 *
+	 * @return StreamingService
+	 */
+	function initializeStream(){
+		cfheader( name = "Content-Type", value = "text/event-stream" );
+		cfheader( name = "Cache-Control", value = "no-cache, no-store, must-revalidate" );
+		cfheader( name = "Pragma", value = "no-cache" );
+		cfheader( name = "Connection", value = "keep-alive" );
+		cfheader( name = "X-Accel-Buffering", value = "no" );
+		return this;
+	}
+
+	/**
+	 * Stream an SSE event to the client
+	 *
+	 * @eventType The type of event (e.g., bundleStart, specEnd)
+	 * @data      The data payload to send as JSON
+	 */
+	function streamEvent( required string eventType, required any data ){
+		writeOutput( "event: #arguments.eventType##chr( 10 )#" );
+		writeOutput( "data: #serializeJSON( arguments.data )##chr( 10 )##chr( 10 )#" );
+		cfflush();
+	}
+
+	/**
+	 * Create streaming callbacks for TestBox
+	 * These callbacks are passed to testbox.runRaw() to stream events during test execution
+	 *
+	 * @return struct of callback functions
+	 */
+	struct function createStreamingCallbacks(){
+		var service = this;
+
+		return {
+			"onBundleStart" : function( target, testResults ){
+				// Note: Bundle stats are not yet created when onBundleStart fires
+				// We get bundle info from the target's metadata instead
+				var targetMD    = getMetadata( arguments.target );
+				var annotations = targetMD.keyExists( "annotations" ) ? targetMD.annotations : targetMD;
+				var bundleName  = structKeyExists( annotations, "displayName" ) ? annotations.displayName : targetMD.name;
+
+				service.streamEvent(
+					"bundleStart",
+					{
+						"name"      : bundleName,
+						"path"      : targetMD.name,
+						"timestamp" : getTickCount()
+					}
+				);
+			},
+			"onBundleEnd" : function( target, testResults ){
+				var bundleStats = arguments.testResults.getBundleStats();
+				var current     = bundleStats[ bundleStats.len() ];
+				service.streamEvent(
+					"bundleEnd",
+					{
+						"id"            : current.id,
+						"name"          : current.name,
+						"path"          : current.path,
+						"totalDuration" : current.totalDuration,
+						"totalSuites"   : current.totalSuites,
+						"totalSpecs"    : current.totalSpecs,
+						"totalPass"     : current.totalPass,
+						"totalFail"     : current.totalFail,
+						"totalError"    : current.totalError,
+						"totalSkipped"  : current.totalSkipped
+					}
+				);
+			},
+			"onSuiteStart" : function( target, testResults, suite ){
+				service.streamEvent(
+					"suiteStart",
+					{
+						"id"        : arguments.suite.id,
+						"name"      : arguments.suite.name,
+						"timestamp" : getTickCount()
+					}
+				);
+			},
+			"onSuiteEnd" : function( target, testResults, suite ){
+				var suiteStats = arguments.testResults.getSuiteStats( arguments.suite.id );
+				service.streamEvent(
+					"suiteEnd",
+					{
+						"id"            : arguments.suite.id,
+						"name"          : arguments.suite.name,
+						"totalDuration" : suiteStats.totalDuration,
+						"totalSpecs"    : suiteStats.totalSpecs,
+						"totalPass"     : suiteStats.totalPass,
+						"totalFail"     : suiteStats.totalFail,
+						"totalError"    : suiteStats.totalError,
+						"totalSkipped"  : suiteStats.totalSkipped
+					}
+				);
+			},
+			"onSpecStart" : function( target, testResults, suite, spec ){
+				service.streamEvent(
+					"specStart",
+					{
+						"id"          : arguments.spec.id,
+						"suiteId"     : arguments.suite.id,
+						"name"        : arguments.spec.name,
+						"displayName" : arguments.spec.displayName ?: arguments.spec.name,
+						"timestamp"   : getTickCount()
+					}
+				);
+			},
+			"onSpecEnd" : function( target, testResults, suite, spec ){
+				var suiteStats = arguments.testResults.getSuiteStats( arguments.suite.id );
+				// Find the spec stats by id
+				var specStats  = suiteStats.specStats.filter( function( s ){
+					return s.id == spec.id;
+				} );
+				var currentSpec = specStats.len() ? specStats[ specStats.len() ] : {};
+
+				service.streamEvent(
+					"specEnd",
+					{
+						"id"             : arguments.spec.id,
+						"suiteId"        : arguments.suite.id,
+						"name"           : arguments.spec.name,
+						"displayName"    : arguments.spec.displayName ?: arguments.spec.name,
+						"status"         : currentSpec.status ?: "unknown",
+						"totalDuration"  : currentSpec.totalDuration ?: 0,
+						"failMessage"    : currentSpec.failMessage ?: "",
+						"failDetail"     : currentSpec.failDetail ?: "",
+						"failStacktrace" : currentSpec.failStacktrace ?: "",
+						"failOrigin"     : currentSpec.failOrigin ?: {},
+						"error"          : currentSpec.error ?: {}
+					}
+				);
+			}
+		};
+	}
+
+}

--- a/system/util/StreamingService.cfc
+++ b/system/util/StreamingService.cfc
@@ -23,14 +23,29 @@ component accessors="true" {
 
 	/**
 	 * Stream an SSE event to the client
+	 * Errors are caught and logged to prevent client disconnects from interrupting test execution.
 	 *
 	 * @eventType The type of event (e.g., bundleStart, specEnd)
 	 * @data      The data payload to send as JSON
 	 */
 	function streamEvent( required string eventType, required any data ){
-		writeOutput( "event: #arguments.eventType##chr( 10 )#" );
-		writeOutput( "data: #serializeJSON( arguments.data )##chr( 10 )##chr( 10 )#" );
-		cfflush(  );
+		try {
+			writeOutput( "event: #arguments.eventType##chr( 10 )#" );
+			writeOutput( "data: #serializeJSON( arguments.data )##chr( 10 )##chr( 10 )#" );
+			cfflush();
+		} catch ( any e ) {
+			// Client may have disconnected during SSE streaming.
+			// Swallow the exception so it does not break the test run.
+			try {
+				writeLog(
+					type = "information",
+					file = "testbox-streaming",
+					text = "StreamingService.streamEvent terminated early: " & e.message
+				);
+			} catch ( any ignore ) {
+				// Ignore logging errors as well
+			}
+		}
 	}
 
 	/**

--- a/system/util/StreamingService.cfc
+++ b/system/util/StreamingService.cfc
@@ -4,6 +4,12 @@
  * ---
  * Service for streaming test results via Server-Sent Events (SSE)
  * Compatible with Adobe ColdFusion 2021+, Lucee 5+, and BoxLang
+ *
+ * LIMITATION: When a test suite uses `asyncAll = true`, the `onSpecStart` and `onSpecEnd`
+ * callbacks are invoked from within a cfthread block. Calling writeOutput and cfflush from
+ * a child thread doesn't write to the parent request's HTTP response buffer, so spec events
+ * for async suites will not be streamed in real-time. Bundle and suite start/end events will
+ * still be streamed normally.
  */
 component accessors="true" {
 

--- a/system/util/StreamingService.cfc
+++ b/system/util/StreamingService.cfc
@@ -38,7 +38,7 @@ component accessors="true" {
 		try {
 			writeOutput( "event: #arguments.eventType##chr( 10 )#" );
 			writeOutput( "data: #serializeJSON( arguments.data )##chr( 10 )##chr( 10 )#" );
-			cfflush();
+			cfflush(  );
 		} catch ( any e ) {
 			// Client may have disconnected during SSE streaming.
 			// Swallow the exception so it does not break the test run.
@@ -84,8 +84,8 @@ component accessors="true" {
 				);
 			},
 			"onBundleEnd" : function( target, testResults ){
-				var targetMD  = getMetadata( arguments.target );
-				var bundleId  = hash( targetMD.name );
+				var targetMD = getMetadata( arguments.target );
+				var bundleId = hash( targetMD.name );
 
 				// Look up bundle stats by path (internal stats use a different id scheme)
 				var bundleStats   = arguments.testResults.getBundleStats();
@@ -94,7 +94,9 @@ component accessors="true" {
 				} );
 
 				// Prefer stats matched by path; fall back to last entry if none found
-				var current = matchingStats.len() ? matchingStats[ matchingStats.len() ] : bundleStats[ bundleStats.len() ];
+				var current = matchingStats.len() ? matchingStats[ matchingStats.len() ] : bundleStats[
+					bundleStats.len()
+				];
 
 				service.streamEvent(
 					"bundleEnd",

--- a/system/util/StreamingService.cfc
+++ b/system/util/StreamingService.cfc
@@ -82,8 +82,15 @@ component accessors="true" {
 				);
 			},
 			"onBundleEnd" : function( target, testResults ){
-				var bundleStats = arguments.testResults.getBundleStats();
-				var current     = bundleStats[ bundleStats.len() ];
+				var bundleStats   = arguments.testResults.getBundleStats();
+				var targetMD      = getMetadata( arguments.target );
+				var matchingStats = bundleStats.filter( function( s ){
+					return s.path == targetMD.name;
+				} );
+
+				// Prefer stats matched by bundle path; fall back to last entry if none found
+				var current = matchingStats.len() ? matchingStats[ matchingStats.len() ] : bundleStats[ bundleStats.len() ];
+
 				service.streamEvent(
 					"bundleEnd",
 					{

--- a/system/util/StreamingService.cfc
+++ b/system/util/StreamingService.cfc
@@ -14,6 +14,14 @@
 component accessors="true" {
 
 	/**
+	 * Whether to actually flush output (set to false for unit testing)
+	 */
+	property
+		name   ="flushEnabled"
+		type   ="boolean"
+		default="true";
+
+	/**
 	 * Initialize streaming mode - sets SSE headers
 	 *
 	 * @return StreamingService
@@ -38,7 +46,10 @@ component accessors="true" {
 		try {
 			writeOutput( "event: #arguments.eventType##chr( 10 )#" );
 			writeOutput( "data: #serializeJSON( arguments.data )##chr( 10 )##chr( 10 )#" );
-			cfflush(  );
+			// Only flush if enabled (disabled during unit testing to prevent response commit)
+			if ( isNull( variables.flushEnabled ) || variables.flushEnabled ) {
+				cfflush(  );
+			}
 		} catch ( any e ) {
 			// Client may have disconnected during SSE streaming.
 			// Swallow the exception so it does not break the test run.

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -12,6 +12,9 @@
 <cfparam name="url.editor" 				default="vscode">
 <cfparam name="url.bundlesPattern" 		default="">
 
+<!--- Streaming mode: streams results via Server-Sent Events (SSE) for real-time progress --->
+<cfparam name="url.streaming"						default="false" type="boolean">
+
 <cfparam name="url.coverageEnabled"					default="true" type="boolean">
 <cfparam name="url.coverageSonarQubeXMLOutputPath"	default="">
 <cfparam name="url.coveragePathToCapture"			default="#expandPath( '/testbox/system/' )#">
@@ -24,5 +27,11 @@
 	  learned this the hard way. Learn from his mistakes. :) --->
 <cfparam name="url.coverageBrowserOutputDir"		default="#expandPath( '/tests/results/coverageReport' )#">
 
-<!--- Include the TestBox HTML Runner --->
-<cfinclude template="/testbox/system/runners/HTMLRunner.cfm" >
+<!--- Include the appropriate runner based on streaming mode --->
+<cfif url.streaming>
+	<!--- Stream results in real-time via SSE --->
+	<cfinclude template="/testbox/system/runners/StreamingRunner.cfm">
+<cfelse>
+	<!--- Traditional batch results --->
+	<cfinclude template="/testbox/system/runners/HTMLRunner.cfm">
+</cfif>

--- a/tests/specs/streaming/StreamingServiceTest.cfc
+++ b/tests/specs/streaming/StreamingServiceTest.cfc
@@ -1,0 +1,305 @@
+/**
+ * This tests the StreamingService functionality in TestBox.
+ */
+component extends="testbox.system.BaseSpec" {
+
+	function run(){
+		describe( "StreamingService", function(){
+			beforeEach( function(){
+				variables.streamingService = new testbox.system.util.StreamingService();
+			} );
+
+			describe( "initialization", function(){
+				it( "can be instantiated", function(){
+					expect( variables.streamingService ).toBeComponent();
+				} );
+
+				it( "returns itself from initializeStream for chaining", function(){
+					// We can't actually test headers in unit tests, but we can verify the return value
+					var result = variables.streamingService.initializeStream();
+					expect( result ).toBe( variables.streamingService );
+				} );
+			} );
+
+			describe( "createStreamingCallbacks", function(){
+				it( "returns a struct of callback functions", function(){
+					var callbacks = variables.streamingService.createStreamingCallbacks();
+					expect( callbacks ).toBeStruct();
+				} );
+
+				it( "includes all required callback functions", function(){
+					var callbacks = variables.streamingService.createStreamingCallbacks();
+
+					expect( callbacks ).toHaveKey( "onBundleStart" );
+					expect( callbacks ).toHaveKey( "onBundleEnd" );
+					expect( callbacks ).toHaveKey( "onSuiteStart" );
+					expect( callbacks ).toHaveKey( "onSuiteEnd" );
+					expect( callbacks ).toHaveKey( "onSpecStart" );
+					expect( callbacks ).toHaveKey( "onSpecEnd" );
+				} );
+
+				it( "all callbacks are closures", function(){
+					var callbacks = variables.streamingService.createStreamingCallbacks();
+
+					expect( isClosure( callbacks.onBundleStart ) ).toBeTrue();
+					expect( isClosure( callbacks.onBundleEnd ) ).toBeTrue();
+					expect( isClosure( callbacks.onSuiteStart ) ).toBeTrue();
+					expect( isClosure( callbacks.onSuiteEnd ) ).toBeTrue();
+					expect( isClosure( callbacks.onSpecStart ) ).toBeTrue();
+					expect( isClosure( callbacks.onSpecEnd ) ).toBeTrue();
+				} );
+			} );
+
+			describe( "SSE event format", function(){
+				it( "produces correct SSE format string", function(){
+					// Test the expected format by building it manually
+					// SSE format is: event: <type>\ndata: <json>\n\n
+					var eventType = "testEvent";
+					var data = { "key" : "value" };
+					var expectedFormat = "event: #eventType##chr( 10 )#data: #serializeJSON( data )##chr( 10 )##chr( 10 )#";
+
+					expect( expectedFormat ).toInclude( "event: testEvent" );
+					expect( expectedFormat ).toInclude( "data: " );
+					// Verify it ends with double newline
+					expect( right( expectedFormat, 2 ) ).toBe( chr( 10 ) & chr( 10 ) );
+				} );
+
+				it( "serializes JSON correctly", function(){
+					var testData = {
+						"id"       : "test-123",
+						"name"     : "Test Spec",
+						"nested"   : { "foo" : "bar" },
+						"arrayVal" : [ 1, 2, 3 ]
+					};
+
+					var json = serializeJSON( testData );
+
+					expect( json ).toInclude( '"id"' );
+					expect( json ).toInclude( '"test-123"' );
+					expect( json ).toInclude( '"nested"' );
+					expect( json ).toInclude( '"foo"' );
+					expect( json ).toInclude( '"bar"' );
+				} );
+			} );
+
+			describe( "callback event data structures", function(){
+				beforeEach( function(){
+					// Create a mocked service that tracks streamEvent calls using $callLog
+					variables.mockService = prepareMock( new testbox.system.util.StreamingService() );
+					// Mock streamEvent to do nothing but record calls
+					variables.mockService.$( "streamEvent" );
+				} );
+
+				it( "onBundleStart sends bundleStart event with metadata", function(){
+					var mockTarget = new testbox.system.BaseSpec();
+					var mockResults = createMock( "testbox.system.TestResult" );
+
+					var callbacks = variables.mockService.createStreamingCallbacks();
+					callbacks.onBundleStart( mockTarget, mockResults );
+
+					var callLog = variables.mockService.$callLog().streamEvent;
+					expect( callLog ).toHaveLength( 1 );
+					expect( callLog[ 1 ][ 1 ] ).toBe( "bundleStart" );
+					expect( callLog[ 1 ][ 2 ] ).toHaveKey( "path" );
+					expect( callLog[ 1 ][ 2 ] ).toHaveKey( "name" );
+					expect( callLog[ 1 ][ 2 ] ).toHaveKey( "timestamp" );
+					expect( callLog[ 1 ][ 2 ].path ).toInclude( "BaseSpec" );
+				} );
+
+				it( "onBundleEnd sends bundleEnd event with statistics", function(){
+					var mockTarget = new testbox.system.BaseSpec();
+					var mockResults = createMock( "testbox.system.TestResult" );
+
+					var bundleStats = [
+						{
+							"id"            : "bundle-123",
+							"name"          : "Test Bundle",
+							"path"          : "tests.specs.TestBundle",
+							"totalDuration" : 100,
+							"totalSuites"   : 2,
+							"totalSpecs"    : 5,
+							"totalPass"     : 4,
+							"totalFail"     : 1,
+							"totalError"    : 0,
+							"totalSkipped"  : 0
+						}
+					];
+					mockResults.$( "getBundleStats", bundleStats );
+
+					var callbacks = variables.mockService.createStreamingCallbacks();
+					callbacks.onBundleEnd( mockTarget, mockResults );
+
+					var callLog = variables.mockService.$callLog().streamEvent;
+					expect( callLog ).toHaveLength( 1 );
+					expect( callLog[ 1 ][ 1 ] ).toBe( "bundleEnd" );
+					expect( callLog[ 1 ][ 2 ].id ).toBe( "bundle-123" );
+					expect( callLog[ 1 ][ 2 ].totalSpecs ).toBe( 5 );
+					expect( callLog[ 1 ][ 2 ].totalPass ).toBe( 4 );
+					expect( callLog[ 1 ][ 2 ].totalFail ).toBe( 1 );
+				} );
+
+				it( "onSuiteStart sends suiteStart event with suite info", function(){
+					var mockTarget = new testbox.system.BaseSpec();
+					var mockResults = createMock( "testbox.system.TestResult" );
+					var mockSuite = {
+						"id"   : "suite-123",
+						"name" : "Test Suite"
+					};
+
+					var callbacks = variables.mockService.createStreamingCallbacks();
+					callbacks.onSuiteStart( mockTarget, mockResults, mockSuite );
+
+					var callLog = variables.mockService.$callLog().streamEvent;
+					expect( callLog ).toHaveLength( 1 );
+					expect( callLog[ 1 ][ 1 ] ).toBe( "suiteStart" );
+					expect( callLog[ 1 ][ 2 ].id ).toBe( "suite-123" );
+					expect( callLog[ 1 ][ 2 ].name ).toBe( "Test Suite" );
+					expect( callLog[ 1 ][ 2 ] ).toHaveKey( "timestamp" );
+				} );
+
+				it( "onSuiteEnd sends suiteEnd event with statistics", function(){
+					var mockTarget = new testbox.system.BaseSpec();
+					var mockResults = createMock( "testbox.system.TestResult" );
+					var mockSuite = { "id" : "suite-123", "name" : "Test Suite" };
+
+					var suiteStats = {
+						"totalDuration" : 50,
+						"totalSpecs"    : 3,
+						"totalPass"     : 2,
+						"totalFail"     : 1,
+						"totalError"    : 0,
+						"totalSkipped"  : 0
+					};
+					mockResults.$( "getSuiteStats", suiteStats );
+
+					var callbacks = variables.mockService.createStreamingCallbacks();
+					callbacks.onSuiteEnd( mockTarget, mockResults, mockSuite );
+
+					var callLog = variables.mockService.$callLog().streamEvent;
+					expect( callLog ).toHaveLength( 1 );
+					expect( callLog[ 1 ][ 1 ] ).toBe( "suiteEnd" );
+					expect( callLog[ 1 ][ 2 ].id ).toBe( "suite-123" );
+					expect( callLog[ 1 ][ 2 ].totalSpecs ).toBe( 3 );
+				} );
+
+				it( "onSpecStart sends specStart event with spec info", function(){
+					var mockTarget = new testbox.system.BaseSpec();
+					var mockResults = createMock( "testbox.system.TestResult" );
+					var mockSuite = { "id" : "suite-123", "name" : "Test Suite" };
+					var mockSpec = {
+						"id"          : "spec-456",
+						"name"        : "should do something",
+						"displayName" : "should do something"
+					};
+
+					var callbacks = variables.mockService.createStreamingCallbacks();
+					callbacks.onSpecStart( mockTarget, mockResults, mockSuite, mockSpec );
+
+					var callLog = variables.mockService.$callLog().streamEvent;
+					expect( callLog ).toHaveLength( 1 );
+					expect( callLog[ 1 ][ 1 ] ).toBe( "specStart" );
+					expect( callLog[ 1 ][ 2 ].id ).toBe( "spec-456" );
+					expect( callLog[ 1 ][ 2 ].suiteId ).toBe( "suite-123" );
+					expect( callLog[ 1 ][ 2 ].name ).toBe( "should do something" );
+				} );
+
+				it( "onSpecEnd sends specEnd event with results", function(){
+					var mockTarget = new testbox.system.BaseSpec();
+					var mockResults = createMock( "testbox.system.TestResult" );
+					var mockSuite = { "id" : "suite-123", "name" : "Test Suite" };
+					var mockSpec = {
+						"id"          : "spec-456",
+						"name"        : "should do something",
+						"displayName" : "should do something"
+					};
+
+					var suiteStats = {
+						"specStats" : [
+							{
+								"id"             : "spec-456",
+								"status"         : "passed",
+								"totalDuration"  : 10,
+								"failMessage"    : "",
+								"failDetail"     : "",
+								"failStacktrace" : "",
+								"failOrigin"     : {},
+								"error"          : {}
+							}
+						]
+					};
+					mockResults.$( "getSuiteStats", suiteStats );
+
+					var callbacks = variables.mockService.createStreamingCallbacks();
+					callbacks.onSpecEnd( mockTarget, mockResults, mockSuite, mockSpec );
+
+					var callLog = variables.mockService.$callLog().streamEvent;
+					expect( callLog ).toHaveLength( 1 );
+					expect( callLog[ 1 ][ 1 ] ).toBe( "specEnd" );
+					expect( callLog[ 1 ][ 2 ].id ).toBe( "spec-456" );
+					expect( callLog[ 1 ][ 2 ].status ).toBe( "passed" );
+					expect( callLog[ 1 ][ 2 ].totalDuration ).toBe( 10 );
+				} );
+
+				it( "onSpecEnd includes failure info for failed specs", function(){
+					var mockTarget = new testbox.system.BaseSpec();
+					var mockResults = createMock( "testbox.system.TestResult" );
+					var mockSuite = { "id" : "suite-123", "name" : "Test Suite" };
+					var mockSpec = {
+						"id"          : "spec-789",
+						"name"        : "should fail gracefully",
+						"displayName" : "should fail gracefully"
+					};
+
+					var suiteStats = {
+						"specStats" : [
+							{
+								"id"             : "spec-789",
+								"status"         : "failed",
+								"totalDuration"  : 15,
+								"failMessage"    : "Expected true but got false",
+								"failDetail"     : "Assertion failed",
+								"failStacktrace" : "at line 42",
+								"failOrigin"     : { "template" : "test.cfc", "line" : 42 },
+								"error"          : {}
+							}
+						]
+					};
+					mockResults.$( "getSuiteStats", suiteStats );
+
+					var callbacks = variables.mockService.createStreamingCallbacks();
+					callbacks.onSpecEnd( mockTarget, mockResults, mockSuite, mockSpec );
+
+					var callLog = variables.mockService.$callLog().streamEvent;
+					expect( callLog[ 1 ][ 1 ] ).toBe( "specEnd" );
+					expect( callLog[ 1 ][ 2 ].status ).toBe( "failed" );
+					expect( callLog[ 1 ][ 2 ].failMessage ).toBe( "Expected true but got false" );
+					expect( callLog[ 1 ][ 2 ].failOrigin ).toHaveKey( "template" );
+				} );
+			} );
+
+			describe( "integration with TestBox callbacks", function(){
+				it( "callbacks can be passed to TestBox runRaw method", function(){
+					var callbacks = variables.streamingService.createStreamingCallbacks();
+
+					// Verify the callback struct has the correct signature for TestBox
+					var requiredCallbacks = [
+						"onBundleStart",
+						"onBundleEnd",
+						"onSuiteStart",
+						"onSuiteEnd",
+						"onSpecStart",
+						"onSpecEnd"
+					];
+
+					for ( var callbackName in requiredCallbacks ) {
+						expect( callbacks ).toHaveKey( callbackName );
+						expect( isClosure( callbacks[ callbackName ] ) ).toBeTrue(
+							"#callbackName# should be a closure"
+						);
+					}
+				} );
+			} );
+		} );
+	}
+
+}

--- a/tests/specs/streaming/StreamingServiceTest.cfc
+++ b/tests/specs/streaming/StreamingServiceTest.cfc
@@ -54,8 +54,8 @@ component extends="testbox.system.BaseSpec" {
 				it( "produces correct SSE format string", function(){
 					// Test the expected format by building it manually
 					// SSE format is: event: <type>\ndata: <json>\n\n
-					var eventType = "testEvent";
-					var data = { "key" : "value" };
+					var eventType      = "testEvent";
+					var data           = { "key" : "value" };
 					var expectedFormat = "event: #eventType##chr( 10 )#data: #serializeJSON( data )##chr( 10 )##chr( 10 )#";
 
 					expect( expectedFormat ).toInclude( "event: testEvent" );
@@ -74,11 +74,11 @@ component extends="testbox.system.BaseSpec" {
 
 					var json = serializeJSON( testData );
 
-					expect( json ).toInclude( '"id"' );
-					expect( json ).toInclude( '"test-123"' );
-					expect( json ).toInclude( '"nested"' );
-					expect( json ).toInclude( '"foo"' );
-					expect( json ).toInclude( '"bar"' );
+					expect( json ).toInclude( """id""" );
+					expect( json ).toInclude( """test-123""" );
+					expect( json ).toInclude( """nested""" );
+					expect( json ).toInclude( """foo""" );
+					expect( json ).toInclude( """bar""" );
 				} );
 			} );
 
@@ -91,7 +91,7 @@ component extends="testbox.system.BaseSpec" {
 				} );
 
 				it( "onBundleStart sends bundleStart event with metadata", function(){
-					var mockTarget = new testbox.system.BaseSpec();
+					var mockTarget  = new testbox.system.BaseSpec();
 					var mockResults = createMock( "testbox.system.TestResult" );
 
 					var callbacks = variables.mockService.createStreamingCallbacks();
@@ -107,7 +107,7 @@ component extends="testbox.system.BaseSpec" {
 				} );
 
 				it( "onBundleEnd sends bundleEnd event with statistics", function(){
-					var mockTarget = new testbox.system.BaseSpec();
+					var mockTarget  = new testbox.system.BaseSpec();
 					var mockResults = createMock( "testbox.system.TestResult" );
 
 					var bundleStats = [
@@ -139,12 +139,9 @@ component extends="testbox.system.BaseSpec" {
 				} );
 
 				it( "onSuiteStart sends suiteStart event with suite info", function(){
-					var mockTarget = new testbox.system.BaseSpec();
+					var mockTarget  = new testbox.system.BaseSpec();
 					var mockResults = createMock( "testbox.system.TestResult" );
-					var mockSuite = {
-						"id"   : "suite-123",
-						"name" : "Test Suite"
-					};
+					var mockSuite   = { "id" : "suite-123", "name" : "Test Suite" };
 
 					var callbacks = variables.mockService.createStreamingCallbacks();
 					callbacks.onSuiteStart( mockTarget, mockResults, mockSuite );
@@ -158,9 +155,9 @@ component extends="testbox.system.BaseSpec" {
 				} );
 
 				it( "onSuiteEnd sends suiteEnd event with statistics", function(){
-					var mockTarget = new testbox.system.BaseSpec();
+					var mockTarget  = new testbox.system.BaseSpec();
 					var mockResults = createMock( "testbox.system.TestResult" );
-					var mockSuite = { "id" : "suite-123", "name" : "Test Suite" };
+					var mockSuite   = { "id" : "suite-123", "name" : "Test Suite" };
 
 					var suiteStats = {
 						"totalDuration" : 50,
@@ -183,10 +180,10 @@ component extends="testbox.system.BaseSpec" {
 				} );
 
 				it( "onSpecStart sends specStart event with spec info", function(){
-					var mockTarget = new testbox.system.BaseSpec();
+					var mockTarget  = new testbox.system.BaseSpec();
 					var mockResults = createMock( "testbox.system.TestResult" );
-					var mockSuite = { "id" : "suite-123", "name" : "Test Suite" };
-					var mockSpec = {
+					var mockSuite   = { "id" : "suite-123", "name" : "Test Suite" };
+					var mockSpec    = {
 						"id"          : "spec-456",
 						"name"        : "should do something",
 						"displayName" : "should do something"
@@ -204,10 +201,10 @@ component extends="testbox.system.BaseSpec" {
 				} );
 
 				it( "onSpecEnd sends specEnd event with results", function(){
-					var mockTarget = new testbox.system.BaseSpec();
+					var mockTarget  = new testbox.system.BaseSpec();
 					var mockResults = createMock( "testbox.system.TestResult" );
-					var mockSuite = { "id" : "suite-123", "name" : "Test Suite" };
-					var mockSpec = {
+					var mockSuite   = { "id" : "suite-123", "name" : "Test Suite" };
+					var mockSpec    = {
 						"id"          : "spec-456",
 						"name"        : "should do something",
 						"displayName" : "should do something"
@@ -241,10 +238,10 @@ component extends="testbox.system.BaseSpec" {
 				} );
 
 				it( "onSpecEnd includes failure info for failed specs", function(){
-					var mockTarget = new testbox.system.BaseSpec();
+					var mockTarget  = new testbox.system.BaseSpec();
 					var mockResults = createMock( "testbox.system.TestResult" );
-					var mockSuite = { "id" : "suite-123", "name" : "Test Suite" };
-					var mockSpec = {
+					var mockSuite   = { "id" : "suite-123", "name" : "Test Suite" };
+					var mockSpec    = {
 						"id"          : "spec-789",
 						"name"        : "should fail gracefully",
 						"displayName" : "should fail gracefully"

--- a/tests/specs/streaming/StreamingServiceTest.cfc
+++ b/tests/specs/streaming/StreamingServiceTest.cfc
@@ -51,18 +51,10 @@ component extends="testbox.system.BaseSpec" {
 			} );
 
 			describe( "SSE event format", function(){
-				it( "streamEvent produces correct SSE format string", function(){
-					// Disable flushing to prevent response commit during testing
-					variables.streamingService.setFlushEnabled( false );
-
-					// Capture the actual output from streamEvent using savecontent
+				it( "formatSSEEvent produces correct SSE format string", function(){
 					var eventType = "testEvent";
 					var data      = { "key" : "value" };
-					var output    = "";
-
-					savecontent variable="output" {
-						variables.streamingService.streamEvent( eventType, data );
-					}
+					var output    = variables.streamingService.formatSSEEvent( eventType, data );
 
 					// Verify SSE format: event: <type>\ndata: <json>\n\n
 					expect( output ).toInclude( "event: testEvent" );
@@ -71,21 +63,14 @@ component extends="testbox.system.BaseSpec" {
 					expect( right( output, 2 ) ).toBe( chr( 10 ) & chr( 10 ) );
 				} );
 
-				it( "streamEvent serializes complex data to JSON correctly", function(){
-					// Disable flushing to prevent response commit during testing
-					variables.streamingService.setFlushEnabled( false );
-
+				it( "formatSSEEvent serializes complex data to JSON correctly", function(){
 					var testData = {
 						"id"       : "test-123",
 						"name"     : "Test Spec",
 						"nested"   : { "foo" : "bar" },
 						"arrayVal" : [ 1, 2, 3 ]
 					};
-					var output = "";
-
-					savecontent variable="output" {
-						variables.streamingService.streamEvent( "testEvent", testData );
-					}
+					var output = variables.streamingService.formatSSEEvent( "testEvent", testData );
 
 					expect( output ).toInclude( """id""" );
 					expect( output ).toInclude( """test-123""" );

--- a/tests/specs/streaming/StreamingServiceTest.cfc
+++ b/tests/specs/streaming/StreamingServiceTest.cfc
@@ -51,34 +51,41 @@ component extends="testbox.system.BaseSpec" {
 			} );
 
 			describe( "SSE event format", function(){
-				it( "produces correct SSE format string", function(){
-					// Test the expected format by building it manually
-					// SSE format is: event: <type>\ndata: <json>\n\n
-					var eventType      = "testEvent";
-					var data           = { "key" : "value" };
-					var expectedFormat = "event: #eventType##chr( 10 )#data: #serializeJSON( data )##chr( 10 )##chr( 10 )#";
+				it( "streamEvent produces correct SSE format string", function(){
+					// Capture the actual output from streamEvent using savecontent
+					var eventType = "testEvent";
+					var data      = { "key" : "value" };
+					var output    = "";
 
-					expect( expectedFormat ).toInclude( "event: testEvent" );
-					expect( expectedFormat ).toInclude( "data: " );
+					savecontent variable="output" {
+						variables.streamingService.streamEvent( eventType, data );
+					}
+
+					// Verify SSE format: event: <type>\ndata: <json>\n\n
+					expect( output ).toInclude( "event: testEvent" );
+					expect( output ).toInclude( "data: " );
 					// Verify it ends with double newline
-					expect( right( expectedFormat, 2 ) ).toBe( chr( 10 ) & chr( 10 ) );
+					expect( right( output, 2 ) ).toBe( chr( 10 ) & chr( 10 ) );
 				} );
 
-				it( "serializes JSON correctly", function(){
+				it( "streamEvent serializes complex data to JSON correctly", function(){
 					var testData = {
 						"id"       : "test-123",
 						"name"     : "Test Spec",
 						"nested"   : { "foo" : "bar" },
 						"arrayVal" : [ 1, 2, 3 ]
 					};
+					var output = "";
 
-					var json = serializeJSON( testData );
+					savecontent variable="output" {
+						variables.streamingService.streamEvent( "testEvent", testData );
+					}
 
-					expect( json ).toInclude( """id""" );
-					expect( json ).toInclude( """test-123""" );
-					expect( json ).toInclude( """nested""" );
-					expect( json ).toInclude( """foo""" );
-					expect( json ).toInclude( """bar""" );
+					expect( output ).toInclude( """id""" );
+					expect( output ).toInclude( """test-123""" );
+					expect( output ).toInclude( """nested""" );
+					expect( output ).toInclude( """foo""" );
+					expect( output ).toInclude( """bar""" );
 				} );
 			} );
 

--- a/tests/specs/streaming/StreamingServiceTest.cfc
+++ b/tests/specs/streaming/StreamingServiceTest.cfc
@@ -298,6 +298,282 @@ component extends="testbox.system.BaseSpec" {
 					}
 				} );
 			} );
+
+			describe( "asyncAll queue support", function(){
+				beforeEach( function(){
+					// Fresh streaming service for each test
+					variables.streamingService = new testbox.system.util.StreamingService();
+				} );
+
+				describe( "hasQueuedEvents", function(){
+					it( "returns false when no events have been queued", function(){
+						expect( variables.streamingService.hasQueuedEvents() ).toBeFalse();
+					} );
+
+					it( "returns true when events have been queued", function(){
+						// Queue an event directly
+						variables.streamingService.queueEvent( "testEvent", { "key" : "value" } );
+						expect( variables.streamingService.hasQueuedEvents() ).toBeTrue();
+					} );
+				} );
+
+				describe( "queueEvent", function(){
+					it( "adds events to the internal queue", function(){
+						variables.streamingService.queueEvent( "specStart", { "id" : "spec-1" } );
+						variables.streamingService.queueEvent(
+							"specEnd",
+							{ "id" : "spec-1", "status" : "passed" }
+						);
+
+						expect( variables.streamingService.hasQueuedEvents() ).toBeTrue();
+						// We should have exactly 2 events queued
+						var events = variables.streamingService.getQueuedEvents();
+						expect( events ).toHaveLength( 2 );
+					} );
+
+					it( "preserves event order (FIFO)", function(){
+						variables.streamingService.queueEvent( "event1", { "order" : 1 } );
+						variables.streamingService.queueEvent( "event2", { "order" : 2 } );
+						variables.streamingService.queueEvent( "event3", { "order" : 3 } );
+
+						var events = variables.streamingService.getQueuedEvents();
+						expect( events[ 1 ].eventType ).toBe( "event1" );
+						expect( events[ 2 ].eventType ).toBe( "event2" );
+						expect( events[ 3 ].eventType ).toBe( "event3" );
+					} );
+
+					it( "stores both eventType and data for each queued event", function(){
+						var testData = { "id" : "spec-123", "name" : "test spec" };
+						variables.streamingService.queueEvent( "specStart", testData );
+
+						var events = variables.streamingService.getQueuedEvents();
+						expect( events[ 1 ] ).toHaveKey( "eventType" );
+						expect( events[ 1 ] ).toHaveKey( "data" );
+						expect( events[ 1 ].eventType ).toBe( "specStart" );
+						expect( events[ 1 ].data.id ).toBe( "spec-123" );
+					} );
+				} );
+
+				describe( "getQueuedEvents", function(){
+					it( "returns an empty array when no events are queued", function(){
+						var events = variables.streamingService.getQueuedEvents();
+						expect( events ).toBeArray();
+						expect( events ).toHaveLength( 0 );
+					} );
+
+					it( "returns all queued events without clearing the queue", function(){
+						variables.streamingService.queueEvent( "event1", { "id" : 1 } );
+						variables.streamingService.queueEvent( "event2", { "id" : 2 } );
+
+						// First call
+						var events1 = variables.streamingService.getQueuedEvents();
+						expect( events1 ).toHaveLength( 2 );
+
+						// Second call should still return 2 events (not cleared)
+						var events2 = variables.streamingService.getQueuedEvents();
+						expect( events2 ).toHaveLength( 2 );
+					} );
+				} );
+
+				describe( "drainQueue", function(){
+					beforeEach( function(){
+						// Create a mock to track streamEvent calls
+						variables.mockService = prepareMock( new testbox.system.util.StreamingService() );
+						// Disable flushing to prevent test issues
+						variables.mockService.setFlushEnabled( false );
+					} );
+
+					it( "streams all queued events in order", function(){
+						// Queue some events
+						variables.mockService.queueEvent( "specStart", { "id" : "spec-1" } );
+						variables.mockService.queueEvent( "specEnd", { "id" : "spec-1" } );
+						variables.mockService.queueEvent( "specStart", { "id" : "spec-2" } );
+
+						// Capture output using savecontent
+						var output          = "";
+						savecontent variable="output" {
+							variables.mockService.drainQueue();
+						}
+
+						// Verify all events were streamed
+						expect( output ).toInclude( "event: specStart" );
+						expect( output ).toInclude( "event: specEnd" );
+						expect( output ).toInclude( "spec-1" );
+						expect( output ).toInclude( "spec-2" );
+					} );
+
+					it( "clears the queue after draining", function(){
+						variables.mockService.queueEvent( "event1", { "id" : 1 } );
+						variables.mockService.queueEvent( "event2", { "id" : 2 } );
+
+						expect( variables.mockService.hasQueuedEvents() ).toBeTrue();
+
+						// Drain the queue (ignore output)
+						savecontent variable="local.ignored" {
+							variables.mockService.drainQueue();
+						}
+
+						// Queue should now be empty
+						expect( variables.mockService.hasQueuedEvents() ).toBeFalse();
+						expect( variables.mockService.getQueuedEvents() ).toHaveLength( 0 );
+					} );
+
+					it( "does nothing when queue is empty", function(){
+						expect( variables.mockService.hasQueuedEvents() ).toBeFalse();
+
+						// Should not throw or produce output
+						var output          = "";
+						savecontent variable="output" {
+							variables.mockService.drainQueue();
+						}
+
+						expect( output ).toBe( "" );
+					} );
+
+					it( "returns the number of events drained", function(){
+						variables.mockService.queueEvent( "event1", {} );
+						variables.mockService.queueEvent( "event2", {} );
+						variables.mockService.queueEvent( "event3", {} );
+
+						savecontent variable="local.ignored" {
+							var count = variables.mockService.drainQueue();
+						}
+
+						expect( count ).toBe( 3 );
+					} );
+				} );
+
+				describe( "thread-safe queue operations", function(){
+					it( "queue is thread-safe for concurrent writes", function(){
+						var service         = new testbox.system.util.StreamingService();
+						var threadCount     = 10;
+						var eventsPerThread = 5;
+
+						// Spawn multiple threads that all queue events concurrently
+						for ( var i = 1; i <= threadCount; i++ ) {
+							thread
+								name      ="queueThread_#i#"
+								action    ="run"
+								service   ="#service#"
+								threadNum ="#i#"
+								eventCount="#eventsPerThread#" {
+								for ( var j = 1; j <= attributes.eventCount; j++ ) {
+									attributes.service.queueEvent(
+										"specEvent",
+										{ "thread" : attributes.threadNum, "event" : j }
+									);
+								}
+							}
+						}
+
+						// Wait for all threads to complete
+						thread
+							action="join"
+							name  ="queueThread_1,queueThread_2,queueThread_3,queueThread_4,queueThread_5,queueThread_6,queueThread_7,queueThread_8,queueThread_9,queueThread_10";
+
+						// Verify all events were queued (no lost events due to race conditions)
+						var events        = service.getQueuedEvents();
+						var expectedCount = threadCount * eventsPerThread;
+						expect( events ).toHaveLength( expectedCount );
+					} );
+				} );
+
+				describe( "streamEvent with thread detection", function(){
+					it( "inThread property is available to detect thread context", function(){
+						// This is a meta-test to ensure we can detect thread context
+						var util = new testbox.system.util.Util();
+						// In the main test thread, we should NOT be in a cfthread
+						expect( util.inThread() ).toBeFalse();
+					} );
+
+					it( "streamEvent queues events when queueMode is enabled", function(){
+						var service = new testbox.system.util.StreamingService();
+						service.setFlushEnabled( false );
+						service.setQueueMode( true );
+
+						// Stream an event - should be queued, not written
+						var output          = "";
+						savecontent variable="output" {
+							service.streamEvent( "specStart", { "id" : "spec-1" } );
+						}
+
+						// No immediate output when queueMode is enabled
+						expect( output ).toBe( "" );
+
+						// Event should be in the queue
+						expect( service.hasQueuedEvents() ).toBeTrue();
+						var events = service.getQueuedEvents();
+						expect( events[ 1 ].eventType ).toBe( "specStart" );
+					} );
+
+					it( "streamEvent writes directly when queueMode is disabled", function(){
+						var service = new testbox.system.util.StreamingService();
+						service.setFlushEnabled( false );
+						service.setQueueMode( false );
+
+						// Stream an event - should be written directly
+						var output          = "";
+						savecontent variable="output" {
+							service.streamEvent( "specStart", { "id" : "spec-1" } );
+						}
+
+						// Output should be written directly
+						expect( output ).toInclude( "event: specStart" );
+
+						// Queue should be empty
+						expect( service.hasQueuedEvents() ).toBeFalse();
+					} );
+
+					it( "streamEvent auto-queues events when called from a thread context", function(){
+						var service = new testbox.system.util.StreamingService();
+						service.setFlushEnabled( false );
+						service.setQueueMode( false ); // queueMode is OFF but should still queue in thread
+
+						// Stream an event from inside a thread
+						thread name="autoQueueTest" action="run" service="#service#" {
+							attributes.service.streamEvent( "specStart", { "id" : "spec-thread" } );
+							attributes.service.streamEvent(
+								"specEnd",
+								{ "id" : "spec-thread", "status" : "passed" }
+							);
+						}
+
+						// Wait for thread to complete
+						thread action="join" name="autoQueueTest";
+
+						// Events should be queued (not written to output since we're in a thread)
+						expect( service.hasQueuedEvents() ).toBeTrue();
+						var events = service.getQueuedEvents();
+						expect( events ).toHaveLength( 2 );
+						expect( events[ 1 ].eventType ).toBe( "specStart" );
+						expect( events[ 2 ].eventType ).toBe( "specEnd" );
+					} );
+
+					it( "onAsyncDrain callback drains queued events", function(){
+						var service   = new testbox.system.util.StreamingService();
+						var callbacks = service.createStreamingCallbacks();
+
+						service.setFlushEnabled( false );
+
+						// Queue some events (simulating what happens in async threads)
+						service.queueEvent( "specStart", { "id" : "spec-1" } );
+						service.queueEvent( "specEnd", { "id" : "spec-1" } );
+
+						expect( service.hasQueuedEvents() ).toBeTrue();
+
+						// Call the drain callback (simulating what runner does after thread join)
+						savecontent variable="local.output" {
+							callbacks.onAsyncDrain();
+						}
+
+						// Queue should be empty after drain
+						expect( service.hasQueuedEvents() ).toBeFalse();
+						// Output should contain the events
+						expect( output ).toInclude( "event: specStart" );
+						expect( output ).toInclude( "event: specEnd" );
+					} );
+				} );
+			} );
 		} );
 	}
 

--- a/tests/specs/streaming/StreamingServiceTest.cfc
+++ b/tests/specs/streaming/StreamingServiceTest.cfc
@@ -52,6 +52,9 @@ component extends="testbox.system.BaseSpec" {
 
 			describe( "SSE event format", function(){
 				it( "streamEvent produces correct SSE format string", function(){
+					// Disable flushing to prevent response commit during testing
+					variables.streamingService.setFlushEnabled( false );
+
 					// Capture the actual output from streamEvent using savecontent
 					var eventType = "testEvent";
 					var data      = { "key" : "value" };
@@ -69,6 +72,9 @@ component extends="testbox.system.BaseSpec" {
 				} );
 
 				it( "streamEvent serializes complex data to JSON correctly", function(){
+					// Disable flushing to prevent response commit during testing
+					variables.streamingService.setFlushEnabled( false );
+
 					var testData = {
 						"id"       : "test-123",
 						"name"     : "Test Spec",
@@ -117,11 +123,15 @@ component extends="testbox.system.BaseSpec" {
 					var mockTarget  = new testbox.system.BaseSpec();
 					var mockResults = createMock( "testbox.system.TestResult" );
 
+					// The id is now generated from hash(path) of the target, not from bundle stats
+					var targetMD   = getMetadata( mockTarget );
+					var expectedId = hash( targetMD.name );
+
 					var bundleStats = [
 						{
 							"id"            : "bundle-123",
 							"name"          : "Test Bundle",
-							"path"          : "tests.specs.TestBundle",
+							"path"          : targetMD.name, // Use the actual target path so stats lookup works
 							"totalDuration" : 100,
 							"totalSuites"   : 2,
 							"totalSpecs"    : 5,
@@ -139,7 +149,7 @@ component extends="testbox.system.BaseSpec" {
 					var callLog = variables.mockService.$callLog().streamEvent;
 					expect( callLog ).toHaveLength( 1 );
 					expect( callLog[ 1 ][ 1 ] ).toBe( "bundleEnd" );
-					expect( callLog[ 1 ][ 2 ].id ).toBe( "bundle-123" );
+					expect( callLog[ 1 ][ 2 ].id ).toBe( expectedId );
 					expect( callLog[ 1 ][ 2 ].totalSpecs ).toBe( 5 );
 					expect( callLog[ 1 ][ 2 ].totalPass ).toBe( 4 );
 					expect( callLog[ 1 ][ 2 ].totalFail ).toBe( 1 );


### PR DESCRIPTION
## Summary

Adds real-time streaming test results output via Server-Sent Events (SSE), allowing test consumers (like testbox-cli) to display test progress as tests execute rather than waiting for the entire test run to complete.

## Features

- **StreamingService.cfc** - Core SSE service that handles event emission during test execution
- **StreamingRunner.cfm** - New runner endpoint that streams test events in real-time
- Enable with `streaming=true` URL parameter

## Event Types

The SSE stream emits the following events:
- `testRunStart` - Emitted when the entire test run begins
- `bundleStart` / `bundleEnd` - Bundle lifecycle events (correlate via `path` field)
- `suiteStart` / `suiteEnd` - Suite lifecycle events
- `specStart` / `specEnd` - Individual spec lifecycle events  
- `testRunEnd` - Final event with complete TestBox results

## Compatibility

- Adobe ColdFusion 2021+
- Lucee 5+
- BoxLang

## Related

- **testbox-cli PR**: Ortus-Solutions/testbox-cli#21 - CLI consumer implementation for streaming output

## Testing

The streaming can be tested by:
1. Starting a TestBox server
2. Accessing `/tests/runner.cfm?streaming=true`
3. Observing SSE events in browser dev tools or using `curl`