### PR TITLE
fix: support full null runtimes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,11 +21,18 @@ jobs:
         cfengine: [ "boxlang@1", "boxlang-cfml@1", "lucee@6", "lucee@7", "adobe@2023", "adobe@2025" ]
         jdkVersion: [ "21" ]
         experimental: [ false ]
+        fullNull: [ false ]
         include:
           - cfengine: "boxlang@be"
             commandbox_version: "6.3.1"
             jdkVersion: "21"
             experimental: true
+            fullNull: false
+          - cfengine: "adobe@2023"
+            commandbox_version: "6.3.1"
+            jdkVersion: "21"
+            experimental: false
+            fullNull: true
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
@@ -48,10 +55,14 @@ jobs:
           box install --production
 
       - name: Start ${{ matrix.cfengine }}/${{ matrix.jdkVersion }} Server
+        env:
+          FULL_NULL: ${{ matrix.fullNull }}
         run: |
           box server start serverConfigFile="server-${{ matrix.cfengine }}.json" --noSaveSettings --debug
 
       - name: Run Tests
+        env:
+          FULL_NULL: ${{ matrix.fullNull }}
         run: |
           box task run taskfile=build/Build target=runTests
 
@@ -60,13 +71,13 @@ jobs:
         if: always()
         with:
           junit_files: tests/results/**/*.xml
-          check_name: "${{ matrix.cfengine }} ${{ matrix.jdkVersion }} Test Results"
+          check_name: "${{ matrix.cfengine }} ${{ matrix.jdkVersion }} fullNull=${{ matrix.fullNull }} Test Results"
 
       - name: Upload Test Results Artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: testbox-test-results-${{ matrix.cfengine }}-${{ matrix.jdkVersion }}
+          name: testbox-test-results-${{ matrix.cfengine }}-${{ matrix.jdkVersion }}-${{ matrix.fullNull }}
           path: |
             tests/results/**/*
 
@@ -79,7 +90,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7
         with:
-          name: Failure Debugging Info - ${{ matrix.cfengine }} - ${{ matrix.jdkVersion }}
+          name: Failure Debugging Info - ${{ matrix.cfengine }} - ${{ matrix.jdkVersion }} - ${{ matrix.fullNull }}
           path: |
             .engine/**/logs/*
             .engine/**/WEB-INF/cfusion/logs/*

--- a/system/BaseSpec.cfc
+++ b/system/BaseSpec.cfc
@@ -1691,7 +1691,7 @@ component {
 	 */
 	function getCBMockData(){
 		// Lazy Load it
-		if ( isNull( variables.$cbMockData ) ) {
+		if ( !structKeyExists( variables, "$cbMockData" ) || isNull( variables.$cbMockData ) ) {
 			variables.$cbMockData = new testbox.system.modules.cbMockData.models.MockData();
 		}
 		return variables.$cbMockData;
@@ -1704,7 +1704,7 @@ component {
 	 */
 	function getUtility(){
 		// Lazy Load it
-		if ( isNull( variables.$utility ) ) {
+		if ( !structKeyExists( variables, "$utility" ) || isNull( variables.$utility ) ) {
 			variables.$utility = new testbox.system.util.Util();
 		}
 		return variables.$utility;
@@ -1717,7 +1717,7 @@ component {
 	 */
 	function getEnv(){
 		// Lazy Load it
-		if ( isNull( variables.$env ) ) {
+		if ( !structKeyExists( variables, "$env" ) || isNull( variables.$env ) ) {
 			variables.$env = new testbox.system.util.Env();
 		}
 		return variables.$env;
@@ -1732,7 +1732,7 @@ component {
 	 */
 	function getMockBox( string generationPath = "" ){
 		// Lazy Load it
-		if ( isNull( this.$mockbox ) ) {
+		if ( !structKeyExists( this, "$mockbox" ) || isNull( this.$mockbox ) ) {
 			variables.$mockbox = this.$mockbox = new testbox.system.MockBox( arguments.generationPath );
 		} else {
 			// Generation path updates

--- a/system/TestBox.cfc
+++ b/system/TestBox.cfc
@@ -256,7 +256,7 @@ component accessors="true" {
 	 */
 	function getEnv(){
 		// Lazy Load it
-		if ( isNull( variables.env ) ) {
+		if ( !structKeyExists( variables, "env" ) || isNull( variables.env ) ) {
 			variables.env = new testbox.system.util.Env();
 		}
 		return variables.env;
@@ -405,16 +405,16 @@ component accessors="true" {
 		);
 
 		// Verify URL conventions for bundle, suites and specs exclusions.
-		if ( !isNull( url.testBundles ) ) {
+		if ( structKeyExists( url, "testBundles" ) && !isNull( url.testBundles ) ) {
 			testBundles.append( listToArray( urlDecode( url.testBundles ) ), true );
 		}
-		if ( !isNull( url.testSuites ) ) {
+		if ( structKeyExists( url, "testSuites" ) && !isNull( url.testSuites ) ) {
 			arguments.testSuites.append( listToArray( urlDecode( url.testSuites ) ), true );
 		}
-		if ( !isNull( url.testSpecs ) ) {
+		if ( structKeyExists( url, "testSpecs" ) && !isNull( url.testSpecs ) ) {
 			arguments.testSpecs.append( listToArray( urlDecode( url.testSpecs ) ), true );
 		}
-		if ( !isNull( url.testMethod ) ) {
+		if ( structKeyExists( url, "testMethod" ) && !isNull( url.testMethod ) ) {
 			arguments.testSpecs.append( listToArray( urlDecode( url.testMethod ) ), true );
 		}
 
@@ -524,16 +524,16 @@ component accessors="true" {
 			isSimpleValue( arguments.testSpecs ) ? listToArray( arguments.testSpecs ) : arguments.testSpecs
 		);
 
-		if ( !isNull( url.testBundles ) ) {
+		if ( structKeyExists( url, "testBundles" ) && !isNull( url.testBundles ) ) {
 			arguments.testBundles.append( listToArray( urlDecode( url.testBundles ) ), true );
 		}
-		if ( !isNull( url.testSuites ) ) {
+		if ( structKeyExists( url, "testSuites" ) && !isNull( url.testSuites ) ) {
 			arguments.testSuites.append( listToArray( urlDecode( url.testSuites ) ), true );
 		}
-		if ( !isNull( url.testSpecs ) ) {
+		if ( structKeyExists( url, "testSpecs" ) && !isNull( url.testSpecs ) ) {
 			arguments.testSpecs.append( listToArray( urlDecode( url.testSpecs ) ), true );
 		}
-		if ( !isNull( url.testMethod ) ) {
+		if ( structKeyExists( url, "testMethod" ) && !isNull( url.testMethod ) ) {
 			arguments.testSpecs.append( listToArray( urlDecode( url.testMethod ) ), true );
 		}
 

--- a/system/coverage/CoverageReporter.cfc
+++ b/system/coverage/CoverageReporter.cfc
@@ -176,10 +176,10 @@ component accessors="true" {
 	 * @opts The options to validate and extend/default.
 	 */
 	private struct function setDefaultOptions( struct opts = {} ){
-		if ( isNull( opts.outputDir ) ) {
+		if ( !structKeyExists( opts, "outputDir" ) || isNull( opts.outputDir ) ) {
 			opts.outputDir = "";
 		}
-		if ( isNull( opts.isBatched ) ) {
+		if ( !structKeyExists( opts, "isBatched" ) || isNull( opts.isBatched ) ) {
 			opts.isBatched = false;
 		}
 		return opts;

--- a/system/coverage/CoverageService.cfc
+++ b/system/coverage/CoverageService.cfc
@@ -136,21 +136,21 @@ component accessors="true" {
 	 * @opts The options to default and check
 	 */
 	private function setDefaultOptions( struct opts = {} ){
-		if ( isNull( opts.enabled ) ) {
+		if ( !structKeyExists( opts, "enabled" ) || isNull( opts.enabled ) ) {
 			opts.enabled = true;
 		}
 
-		if ( isNull( opts.sonarQube ) ) {
+		if ( !structKeyExists( opts, "sonarQube" ) || isNull( opts.sonarQube ) ) {
 			opts.sonarQube = {};
 		}
-		if ( isNull( opts.sonarQube.XMLOutputPath ) ) {
+		if ( !structKeyExists( opts.sonarQube, "XMLOutputPath" ) || isNull( opts.sonarQube.XMLOutputPath ) ) {
 			opts.sonarQube.XMLOutputPath = "";
 		}
 
-		if ( isNull( opts.browser ) ) {
+		if ( !structKeyExists( opts, "browser" ) || isNull( opts.browser ) ) {
 			opts.browser = {};
 		}
-		if ( isNull( opts.browser.outputDir ) ) {
+		if ( !structKeyExists( opts.browser, "outputDir" ) || isNull( opts.browser.outputDir ) ) {
 			opts.browser.outputDir = "";
 		}
 
@@ -172,34 +172,35 @@ component accessors="true" {
 			}
 		}
 
-		if ( isNull( opts.coverageTresholds ) ) {
+		if ( !structKeyExists( opts, "coverageTresholds" ) || isNull( opts.coverageTresholds ) ) {
 			opts.coverageTresholds = {};
 		}
-		if ( isNull( opts.coverageTresholds.good ) ) {
+		if ( !structKeyExists( opts.coverageTresholds, "good" ) || isNull( opts.coverageTresholds.good ) ) {
 			opts.coverageTresholds.good = 85;
 		}
-		if ( isNull( opts.coverageTresholds.bad ) ) {
+		if ( !structKeyExists( opts.coverageTresholds, "bad" ) || isNull( opts.coverageTresholds.bad ) ) {
 			opts.coverageTresholds.bad = 50;
 		}
 
-		if ( isNull( opts.pathToCapture ) ) {
+		if ( !structKeyExists( opts, "pathToCapture" ) || isNull( opts.pathToCapture ) ) {
 			opts.pathToCapture = "";
 		}
-		if ( isNull( opts.whitelist ) ) {
+		if ( !structKeyExists( opts, "whitelist" ) || isNull( opts.whitelist ) ) {
 			opts.whitelist = "";
 		}
-		if ( isNull( opts.blacklist ) ) {
+		if ( !structKeyExists( opts, "blacklist" ) || isNull( opts.blacklist ) ) {
 			opts.blacklist = "";
 		}
-		if ( isNull( opts.isBatched ) ) {
+		if ( !structKeyExists( opts, "isBatched" ) || isNull( opts.isBatched ) ) {
 			opts.isBatched = false;
 		}
 
 		// If no path provided to capture
 		if ( !len( opts.pathToCapture ) ) {
 			// Look for a /root mapping which is a common ColdBox convention
-			if ( !isNull( getApplicationMetadata().mappings ) ) {
-				var mappings = getApplicationMetadata().mappings;
+			var appMetadata = getApplicationMetadata();
+			if ( structKeyExists( appMetadata, "mappings" ) && !isNull( appMetadata.mappings ) ) {
+				var mappings = appMetadata.mappings;
 			} else {
 				var mappings = {};
 			}

--- a/system/mockutils/MockGenerator.cfc
+++ b/system/mockutils/MockGenerator.cfc
@@ -101,18 +101,20 @@ component accessors="true" {
 				udfOut.append( "						" );
 
 				// Is it required?
-				if ( !isNull( thisParam.required ) && thisParam.required ) {
+				if ( structKeyExists( thisParam, "required" ) && !isNull( thisParam.required ) && thisParam.required ) {
 					udfOut.append( "required " );
 				}
 
 				// If we have a type, add it
-				if ( !isNull( thisParam.type ) ) {
+				if ( structKeyExists( thisParam, "type" ) && !isNull( thisParam.type ) ) {
 					udfOut.append( thisParam.type & " " );
 				}
 
 				// Param name and default
 				udfOut.append( thisParam.name & " " );
-				if ( !isNull( thisParam.default ) && thisParam.default != "[runtime expression]" ) {
+				if (
+					structKeyExists( thisParam, "default" ) && !isNull( thisParam.default ) && thisParam.default != "[runtime expression]"
+				) {
 					udfOut.append( "= " & outputQuotedValue( thisParam.default ) & " " );
 				}
 

--- a/system/runners/BDDRunner.cfc
+++ b/system/runners/BDDRunner.cfc
@@ -157,7 +157,7 @@ component
 						e,
 						arguments.target,
 						arguments.testResults,
-						isNull( thisSuite ) ? {} : thisSuite
+						!structKeyExists( local, "thisSuite" ) || isNull( local.thisSuite ) ? {} : local.thisSuite
 					]
 				);
 			}

--- a/system/runners/BaseRunner.cfc
+++ b/system/runners/BaseRunner.cfc
@@ -272,7 +272,7 @@ component {
 		var md = getMetadata( arguments.target )
 		var md = md.keyExists( "annotations" ) ? md.annotations : md
 
-		if ( isNull( md.skip ) ) {
+		if ( !structKeyExists( md, "skip" ) || isNull( md.skip ) ) {
 			return false
 		}
 

--- a/system/util/CFMappingHelper.cfc
+++ b/system/util/CFMappingHelper.cfc
@@ -13,7 +13,7 @@ component {
 	 */
 	CFMappingHelper function addCustomTagPath( required path ){
 		var appMetadata = getApplicationMetadata();
-		if ( isNull( appMetadata.customTagPaths ) ) {
+		if ( !structKeyExists( appMetadata, "customTagPaths" ) || isNull( appMetadata.customTagPaths ) ) {
 			appMetadata.customTagPaths = "";
 		}
 		getPageContext()

--- a/system/util/Env.cfc
+++ b/system/util/Env.cfc
@@ -84,7 +84,7 @@ component singleton {
 	 * Retrieve an instance of Java System
 	 */
 	function getJavaSystem(){
-		if ( isNull( variables.javaSystem ) ) {
+		if ( !structKeyExists( variables, "javaSystem" ) || isNull( variables.javaSystem ) ) {
 			variables.javaSystem = createObject( "java", "java.lang.System" );
 		}
 		return variables.javaSystem;

--- a/system/util/Util.cfc
+++ b/system/util/Util.cfc
@@ -200,7 +200,7 @@ component {
 	 */
 	private function getEngineMappingHelper(){
 		// Lazy load the helper
-		if ( isNull( variables.engineMappingHelper ) ) {
+		if ( !structKeyExists( variables, "engineMappingHelper" ) || isNull( variables.engineMappingHelper ) ) {
 			if ( server.keyExists( "boxlang" ) ) {
 				variables.engineMappingHelper = new BoxLangMappingHelper();
 			} else if ( listFindNoCase( "Lucee", server.coldfusion.productname ) ) {

--- a/tests/specs/FullNullSupportTest.cfc
+++ b/tests/specs/FullNullSupportTest.cfc
@@ -1,0 +1,29 @@
+/**
+ * Regression coverage for public TestBox flows when missing values are real nulls.
+ */
+component extends="testbox.system.BaseSpec" {
+
+	function run(){
+		describe( "Full null support", function(){
+			it( "lazy loads public helper services from an uninitialized state", function(){
+				expect( getCBMockData() ).toBeComponent();
+				expect( getUtility() ).toBeComponent();
+				expect( getEnv() ).toBeComponent();
+				expect( getMockBox() ).toBeComponent();
+			} );
+
+			it( "discovers tests without optional URL filters", function(){
+				var discovery = new testbox.system.TestBox(
+					bundles = [ "tests.specs.BaseTest" ],
+					options = { "coverage" : { "enabled" : false } }
+				).dryRun();
+
+				expect( discovery ).toBeStruct().toHaveKey( "bundles,filters,summary" );
+				expect( discovery.filters.testBundles ).toBeEmpty();
+				expect( discovery.filters.testSuites ).toBeEmpty();
+				expect( discovery.filters.testSpecs ).toBeEmpty();
+			} );
+		} );
+	}
+
+}

--- a/tests/specs/coverage/CoverageServiceTest.cfc
+++ b/tests/specs/coverage/CoverageServiceTest.cfc
@@ -47,6 +47,16 @@ component extends="testbox.system.BaseSpec" {
 					expect( mockGenerator.$never( "generateData" ) ).toBeTrue();
 				} );
 			} );
+
+			it( "applies defaults when optional coverage settings are omitted", function(){
+				var options = new system.coverage.CoverageService( { "enabled" : false } ).getCoverageOptions();
+
+				expect( options.browser.outputDir ).toBe( "" );
+				expect( options.coverageTresholds ).toBe( { "good" : 85, "bad" : 50 } );
+				expect( options.sonarQube.XMLOutputPath ).toBe( "" );
+				expect( options.isBatched ).toBeFalse();
+			} );
+
 			describe( "enabled coverage, disabled coverage batching", function(){
 				beforeEach( function(){
 					if ( structKeyExists( variables, "model" ) ) {


### PR DESCRIPTION
## Summary

- distinguish absent optional values from real nulls before dereferencing TestBox configuration and lazy services
- preserve default coverage, discovery, runner, metadata, and mock-generation behavior when full null support is enabled
- add an Adobe 2023 full-null CI job alongside the existing engine matrix

## Regression coverage

- adds FullNullSupportTest, which exercises the public BaseSpec helper APIs and TestBox.dryRun without URL filters
- adds public CoverageService option-default coverage for omitted nested settings
- both specs reproduce failures seen while enabling Quick full-null coverage before the source guards are applied

## Validation

- Lucee 6, full null: 415 passed, 0 failed, 0 errored, 22 skipped
- Lucee 6, standard null behavior: 415 passed, 0 failed, 0 errored, 22 skipped
- cfformat check passed for all changed CFML files
- git diff --check passed

Supports the full-null engine matrix work in https://github.com/coldbox-modules/quick/pull/312.